### PR TITLE
[25.02.28 / TASK-128] Feature - noti app & 공지 API

### DIFF
--- a/src/configs/db.config.ts
+++ b/src/configs/db.config.ts
@@ -6,16 +6,22 @@ const { Pool } = pg;
 
 dotenv.config();
 
-const pool = new Pool({
+// local 세팅 및 접근시 SSL 은 기본 X, production 에서만 추가
+const poolConfig: pg.PoolConfig = {
   database: process.env.DATABASE_NAME,
   user: process.env.POSTGRES_USER,
   host: process.env.POSTGRES_HOST,
   password: process.env.POSTGRES_PASSWORD,
   port: Number(process.env.POSTGRES_PORT),
-  ssl: {
+};
+
+if (process.env.NODE_ENV === 'production') {
+  poolConfig.ssl = {
     rejectUnauthorized: false,
-  },
-});
+  };
+}
+
+const pool = new Pool(poolConfig);
 
 (async () => {
   const client = await pool.connect();

--- a/src/controllers/noti.controller.ts
+++ b/src/controllers/noti.controller.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import logger from '@/configs/logger.config';
+import { NotiService } from "@/services/noti.service";
+import { NotiPostsResponseDto } from "@/types/dto/responses/notiResponse.type";
+
+export class NotiController {
+  constructor(private notiService: NotiService) { }
+
+  getAllNotiPosts: RequestHandler = async (
+    req: Request,
+    res: Response<NotiPostsResponseDto>,
+    next: NextFunction,
+  ) => {
+    try {
+      const result = await this.notiService.getAllNotiPosts();
+      const response = new NotiPostsResponseDto(
+        true,
+        '전체 noti post 조회에 성공하였습니다.',
+        { posts: result },
+        null,
+      );
+      res.status(200).json(response);
+    } catch (error) {
+      logger.error('전체 조회 실패:', error);
+      next(error);
+    }
+  };
+}

--- a/src/repositories/noti.repository.ts
+++ b/src/repositories/noti.repository.ts
@@ -5,17 +5,18 @@ import { DBError } from '@/exception';
 export class NotiRepository {
   constructor(private pool: Pool) { }
 
-  async getAllNotiPosts() {
+  async getAllNotiPosts(limit: number = 5) {
     try {
       const query = `
         SELECT
           n.id,
           n.title,
           n.content,
-          n.created_at,
-        FROM "noti_notipost" n
+          n.created_at
+        FROM noti_notipost n
         WHERE n.is_active = true
-        ORDER BY n.id DESC;
+        ORDER BY n.id DESC
+        LIMIT ${limit};
       `;
 
       const result = await this.pool.query(query);

--- a/src/repositories/noti.repository.ts
+++ b/src/repositories/noti.repository.ts
@@ -1,0 +1,28 @@
+import { Pool } from 'pg';
+import logger from '@/configs/logger.config';
+import { DBError } from '@/exception';
+
+export class NotiRepository {
+  constructor(private pool: Pool) { }
+
+  async getAllNotiPosts() {
+    try {
+      const query = `
+        SELECT
+          n.id,
+          n.title,
+          n.content,
+          n.created_at,
+        FROM "noti_notipost" n
+        WHERE n.is_active = true
+        ORDER BY n.id DESC;
+      `;
+
+      const result = await this.pool.query(query);
+      return result.rows;
+    } catch (error) {
+      logger.error('Noti Repo getAllNotiPosts Error : ', error);
+      throw new DBError('알림 조회 중 문제가 발생했습니다.');
+    }
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,6 +2,7 @@ import express, { Router } from 'express';
 import UserRouter from './user.router';
 import TrackingRouter from './tracking.router';
 import PostRouter from './post.router';
+import NotiRouter from './noti.router';
 
 const router: Router = express.Router();
 
@@ -12,4 +13,5 @@ router.use('/ping', (req, res) => {
 router.use('/', UserRouter);
 router.use('/', TrackingRouter);
 router.use('/', PostRouter);
+router.use('/', NotiRouter);
 export default router;

--- a/src/routes/noti.router.ts
+++ b/src/routes/noti.router.ts
@@ -1,0 +1,44 @@
+import express, { Router } from 'express';
+import pool from '@/configs/db.config';
+
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { NotiRepository } from '@/repositories/noti.repository';
+import { NotiService } from '@/services/noti.service';
+import { NotiController } from '@/controllers/noti.controller';
+
+/**
+ * @swagger
+ * tags:
+ *   name: Notifications
+ *   description: 알림 관련 API
+ */
+const router: Router = express.Router();
+
+const notiRepository = new NotiRepository(pool);
+const notiService = new NotiService(notiRepository);
+const notiController = new NotiController(notiService);
+
+/**
+ * @swagger
+ * /notis:
+ *   get:
+ *     summary: 공지 게시글 목록 전체 조회
+ *     description: 사용자의 알림 게시글 목록을 조회합니다
+ *     tags: [Notifications]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 알림 게시글 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/NotiPostsResponseDto'
+ *       401:
+ *         description: 인증되지 않은 사용자
+ *       500:
+ *         description: 서버 에러
+ */
+router.get('/notis', authMiddleware.login, notiController.getAllNotiPosts);
+
+export default router;

--- a/src/services/noti.service.ts
+++ b/src/services/noti.service.ts
@@ -1,0 +1,10 @@
+import { NotiRepository } from "@/repositories/noti.repository";
+import { NotiPost } from "@/types/models/NotiPost.type";
+
+export class NotiService {
+    constructor(private notiRepo: NotiRepository) {}
+
+    async getAllNotiPosts(): Promise<NotiPost[]> {
+        return await this.notiRepo.getAllNotiPosts();
+    }
+}

--- a/src/types/dto/responses/notiResponse.type.ts
+++ b/src/types/dto/responses/notiResponse.type.ts
@@ -1,0 +1,8 @@
+import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
+import { NotiPost } from '@/types/models/NotiPost.type';
+
+interface NotiPostsResponseData {
+    posts: NotiPost[];
+}
+
+export class NotiPostsResponseDto extends BaseResponseDto<NotiPostsResponseData> { }

--- a/src/types/dto/responses/notiResponse.type.ts
+++ b/src/types/dto/responses/notiResponse.type.ts
@@ -1,8 +1,33 @@
 import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
 import { NotiPost } from '@/types/models/NotiPost.type';
 
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     NotiPostsResponseData:
+ *       type: object
+ *       properties:
+ *         posts:
+ *           type: array
+ *           description: 알림 게시글 목록
+ *           items:
+ *             $ref: '#/components/schemas/NotiPost'
+ */
 interface NotiPostsResponseData {
     posts: NotiPost[];
 }
 
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     NotiPostsResponseDto:
+ *       allOf:
+ *         - $ref: '#/components/schemas/BaseResponseDto'
+ *         - type: object
+ *           properties:
+ *             data:
+ *               $ref: '#/components/schemas/NotiPostsResponseData'
+ */
 export class NotiPostsResponseDto extends BaseResponseDto<NotiPostsResponseData> { }

--- a/src/types/models/NotiPost.type.ts
+++ b/src/types/models/NotiPost.type.ts
@@ -1,0 +1,9 @@
+export interface NotiPost {
+    id: number;
+    title: string;
+    content: string;
+    created_at: Date;
+    // is_active: boolean;
+    // updated_at: Date;
+    // author?: User | null;
+}


### PR DESCRIPTION
- noti app 추가 api 쪽 대응개발
- "도메인" 성격이 추가 되었기 때문에 controller / service / repo / router 모두 추가
- notion 내용 필수 참조 필요 특히 SQL 쿼리
- @six-standard 접두사 `/api` 가 붙기 때문에 `/api/notis/` 가 실제 end point


PS. jest code 도 같이 포함하려고 했는데, 천휘님 테코 형태에 맞춰드려야 예의일 것 같아 우선은 제외해뒀어요!
PS. 핑계 같지만.. 핑계인가..?! 🙏