### PR TITLE
[25.03.20 / TASK-132] Feature - view growth order

### DIFF
--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -7,7 +7,13 @@ export class PostService {
 
   async getAllposts(userId: number, cursor?: string, sort: string = '', isAsc?: boolean, limit: number = 15) {
     try {
-      const result = await this.postRepo.findPostsByUserId(userId, cursor, sort, isAsc, limit);
+      let result = null;
+      if (sort === "viewGrowth") {
+        result = await this.postRepo.findPostsByUserIdWithGrowthMetrics(userId, cursor, isAsc, limit);
+      }
+      else {
+        result = await this.postRepo.findPostsByUserId(userId, cursor, sort, isAsc, limit);
+      }
 
       const transformedPosts = result.posts.map((post) => ({
         id: post.id,

--- a/src/types/dto/requests/getAllPostsQuery.type.ts
+++ b/src/types/dto/requests/getAllPostsQuery.type.ts
@@ -7,15 +7,16 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
  *   schemas:
  *     PostSortType:
  *       type: string
- *       enum: ['', 'dailyViewCount', 'dailyLikeCount']
+ *       enum: ['', 'dailyViewCount', 'dailyLikeCount', 'viewGrowth']
  *       description: |
  *         포스트 정렬 기준
  *         * '' - 작성일
  *         * 'dailyViewCount' - 조회수
  *         * 'dailyLikeCount' - 좋아요수
+ *         * 'viewGrowth' - 조회수 증가량
  *       default: ''
  */
-export type PostSortType = '' | 'dailyViewCount' | 'dailyLikeCount';
+export type PostSortType = '' | 'dailyViewCount' | 'dailyLikeCount' | 'viewGrowth';
 
 export interface GetAllPostsQuery {
   cursor?: string;


### PR DESCRIPTION
## 🔥 변경 사항
트래픽 데일리 상승량 순서 정렬

## 📸 스크린샷 (UI 변경 시 필수)
![image](https://github.com/user-attachments/assets/ea7cd0d3-86b7-451f-87f7-a8fd5608b360)
![image](https://github.com/user-attachments/assets/7ce10ca5-6a3a-4628-9ca3-30f926f70f70)


## 📌 체크리스트
- [X] 기능이 정상적으로 동작하는지 테스트 완료
- [X] 코드 스타일 가이드 준수 여부 확인
- [X] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 포스트 조회 시, 조회수 성장률을 기준으로 정렬하는 옵션이 추가되어 트렌딩 콘텐츠를 쉽게 파악할 수 있습니다.
  - 포스트에 조회수 및 좋아요의 성장 지표가 제공되어 더욱 풍부한 데이터를 확인할 수 있습니다.
  - 페이지네이션 기능이 개선되어 연속 조회 시 중복 없이 정확한 결과를 전달합니다.

- **문서**
  - API 문서에 새로운 정렬 옵션 "viewGrowth"가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->