### PR TITLE
[25.04.22 / TASK-100] Feature - Leaderboard 도메인 추가 및 조회 API 구현

### DIFF
--- a/src/controllers/leaderboard.controller.ts
+++ b/src/controllers/leaderboard.controller.ts
@@ -1,0 +1,14 @@
+import { LeaderboardService } from '@/services/leaderboard.service';
+import { NextFunction, RequestHandler, Request, Response } from 'express';
+
+export class LeaderboardController {
+  constructor(private leaderboardService: LeaderboardService) {}
+
+  getLeaderboard: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      res.status(200).json({ message: 'ok' });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/controllers/leaderboard.controller.ts
+++ b/src/controllers/leaderboard.controller.ts
@@ -1,25 +1,48 @@
 import logger from '@/configs/logger.config';
 import { NextFunction, RequestHandler, Request, Response } from 'express';
 import { LeaderboardService } from '@/services/leaderboard.service';
-import { GetLeaderboardQuery, LeaderboardResponseDto } from '@/types/index';
+import {
+  GetUserLeaderboardQuery,
+  GetPostLeaderboardQuery,
+  UserLeaderboardResponseDto,
+  PostLeaderboardResponseDto,
+} from '@/types/index';
 
 export class LeaderboardController {
   constructor(private leaderboardService: LeaderboardService) {}
 
-  getLeaderboard: RequestHandler = async (
-    req: Request<object, object, object, GetLeaderboardQuery>,
-    res: Response<LeaderboardResponseDto>,
+  getUserLeaderboard: RequestHandler = async (
+    req: Request<object, object, object, GetUserLeaderboardQuery>,
+    res: Response<UserLeaderboardResponseDto>,
     next: NextFunction,
   ) => {
     try {
-      const { type, sort, dateRange, limit } = req.query;
+      const { sort, dateRange, limit } = req.query;
 
-      const result = await this.leaderboardService.getLeaderboard(type, sort, dateRange, limit);
-      const response = new LeaderboardResponseDto(true, '리더보드 조회에 성공하였습니다.', result, null);
+      const users = await this.leaderboardService.getUserLeaderboard(sort, dateRange, limit);
+      const response = new UserLeaderboardResponseDto(true, '사용자 리더보드 조회에 성공하였습니다.', users, null);
 
       res.status(200).json(response);
     } catch (error) {
-      logger.error('리더보드 조회 실패:', error);
+      logger.error('사용자 리더보드 조회 실패:', error);
+      next(error);
+    }
+  };
+
+  getPostLeaderboard: RequestHandler = async (
+    req: Request<object, object, object, GetPostLeaderboardQuery>,
+    res: Response<PostLeaderboardResponseDto>,
+    next: NextFunction,
+  ) => {
+    try {
+      const { sort, dateRange, limit } = req.query;
+
+      const posts = await this.leaderboardService.getPostLeaderboard(sort, dateRange, limit);
+      const response = new PostLeaderboardResponseDto(true, '게시물 리더보드 조회에 성공하였습니다.', posts, null);
+
+      res.status(200).json(response);
+    } catch (error) {
+      logger.error('게시물 리더보드 조회 실패:', error);
       next(error);
     }
   };

--- a/src/controllers/leaderboard.controller.ts
+++ b/src/controllers/leaderboard.controller.ts
@@ -1,8 +1,7 @@
 import logger from '@/configs/logger.config';
-import { LeaderboardService } from '@/services/leaderboard.service';
-import { GetLeaderboardQuery } from '@/types/dto/requests/getLeaderboardQuery.type';
-import { LeaderboardResponseDto } from '@/types/dto/responses/leaderboardResponse.type';
 import { NextFunction, RequestHandler, Request, Response } from 'express';
+import { LeaderboardService } from '@/services/leaderboard.service';
+import { GetLeaderboardQuery, LeaderboardResponseDto } from '@/types/index';
 
 export class LeaderboardController {
   constructor(private leaderboardService: LeaderboardService) {}

--- a/src/controllers/leaderboard.controller.ts
+++ b/src/controllers/leaderboard.controller.ts
@@ -1,13 +1,26 @@
+import logger from '@/configs/logger.config';
 import { LeaderboardService } from '@/services/leaderboard.service';
+import { GetLeaderboardQuery } from '@/types/dto/requests/getLeaderboardQuery.type';
+import { LeaderboardResponseDto } from '@/types/dto/responses/leaderboardResponse.type';
 import { NextFunction, RequestHandler, Request, Response } from 'express';
 
 export class LeaderboardController {
   constructor(private leaderboardService: LeaderboardService) {}
 
-  getLeaderboard: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
+  getLeaderboard: RequestHandler = async (
+    req: Request<object, object, object, GetLeaderboardQuery>,
+    res: Response<LeaderboardResponseDto>,
+    next: NextFunction,
+  ) => {
     try {
-      res.status(200).json({ message: 'ok' });
+      const { type, sort, dateRange, limit } = req.query;
+
+      const result = await this.leaderboardService.getLeaderboard(type, sort, dateRange, limit);
+      const response = new LeaderboardResponseDto(true, '리더보드 조회에 성공하였습니다.', result, null);
+
+      res.status(200).json(response);
     } catch (error) {
+      logger.error('리더보드 조회 실패:', error);
       next(error);
     }
   };

--- a/src/repositories/__test__/leaderboard.repo.test.ts
+++ b/src/repositories/__test__/leaderboard.repo.test.ts
@@ -32,7 +32,7 @@ describe('LeaderboardRepository', () => {
     it('사용자 통계 배열로 이루어진 리더보드를 반환해야 한다', async () => {
       const mockResult = [
         {
-          id: 1,
+          id: '1',
           email: 'test@test.com',
           total_views: 100,
           total_likes: 50,
@@ -42,7 +42,7 @@ describe('LeaderboardRepository', () => {
           post_diff: 1,
         },
         {
-          id: 2,
+          id: '2',
           email: 'test2@test.com',
           total_views: 200,
           total_likes: 100,
@@ -119,7 +119,7 @@ describe('LeaderboardRepository', () => {
     it('게시물 통계 배열로 이루어진 리더보드를 반환해야 한다', async () => {
       const mockResult = [
         {
-          id: 2,
+          id: '2',
           title: 'test2',
           slug: 'test2',
           total_views: 200,
@@ -129,7 +129,7 @@ describe('LeaderboardRepository', () => {
           released_at: '2025-01-02',
         },
         {
-          id: 1,
+          id: '1',
           title: 'test',
           slug: 'test',
           total_views: 100,

--- a/src/repositories/__test__/leaderboard.repo.test.ts
+++ b/src/repositories/__test__/leaderboard.repo.test.ts
@@ -1,6 +1,6 @@
+import { Pool, QueryResult } from 'pg';
 import { DBError } from '@/exception';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
-import { Pool, QueryResult } from 'pg';
 
 jest.mock('pg');
 

--- a/src/repositories/__test__/leaderboard.repo.test.ts
+++ b/src/repositories/__test__/leaderboard.repo.test.ts
@@ -1,0 +1,271 @@
+import { DBError } from '@/exception';
+import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
+import { Pool, QueryResult } from 'pg';
+
+jest.mock('pg');
+
+const mockPool: {
+  query: jest.Mock<Promise<QueryResult<Record<string, unknown>>>, unknown[]>;
+} = {
+  query: jest.fn(),
+};
+
+describe('LeaderboardRepository', () => {
+  let repo: LeaderboardRepository;
+
+  beforeEach(() => {
+    repo = new LeaderboardRepository(mockPool as unknown as Pool);
+  });
+
+  describe('getLeaderboard', () => {
+    it('type이 post인 경우 post 데이터를 반환해야 한다.', async () => {
+      const mockResult = [
+        {
+          id: 2,
+          title: 'test2',
+          slug: 'test2',
+          total_views: 200,
+          total_likes: 100,
+          view_diff: 20,
+          like_diff: 10,
+          released_at: '2025-01-02',
+        },
+        {
+          id: 1,
+          title: 'test',
+          slug: 'test',
+          total_views: 100,
+          total_likes: 50,
+          view_diff: 10,
+          like_diff: 5,
+          released_at: '2025-01-01',
+        },
+      ];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('post', 'viewCount', 30, 10);
+
+      expect(result).toEqual(mockResult);
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('FROM posts_post p'), expect.anything());
+    });
+
+    it('type이 user인 경우 user 데이터를 반환해야 한다.', async () => {
+      const mockResult = [
+        {
+          id: 1,
+          email: 'test@test.com',
+          total_views: 100,
+          total_likes: 50,
+          total_posts: 1,
+          view_diff: 20,
+          like_diff: 10,
+          post_diff: 1,
+        },
+        {
+          id: 2,
+          email: 'test2@test.com',
+          total_views: 200,
+          total_likes: 100,
+          total_posts: 2,
+          view_diff: 10,
+          like_diff: 5,
+          post_diff: 1,
+        },
+      ];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('user', 'viewCount', 30, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('FROM users_user u'), expect.anything());
+      expect(result).toEqual(mockResult);
+    });
+
+    it('sort가 조회수인 경우 정렬 순서를 보장해야 한다.', async () => {
+      const mockResult = [
+        { view_diff: 20, like_diff: 5, post_diff: 1 },
+        { view_diff: 10, like_diff: 10, post_diff: 2 },
+      ];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('user', 'viewCount', 30, 10);
+
+      expect(result).toEqual(mockResult);
+      expect(result[0].view_diff).toBeGreaterThan(result[1].view_diff);
+    });
+
+    it('sort가 좋아요 수인 경우 정렬 순서를 보장해야 한다.', async () => {
+      const mockResult = [
+        { view_diff: 10, like_diff: 10, post_diff: 1 },
+        { view_diff: 20, like_diff: 5, post_diff: 1 },
+      ];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('user', 'likeCount', 30, 10);
+
+      expect(result).toEqual(mockResult);
+      expect(result[0].like_diff).toBeGreaterThan(result[1].like_diff);
+    });
+
+    it('sort가 게시물 수인 경우 정렬 순서를 보장해야 한다.', async () => {
+      const mockResult = [
+        { view_diff: 10, like_diff: 10, post_diff: 4 },
+        { view_diff: 20, like_diff: 5, post_diff: 1 },
+      ];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('user', 'postCount', 30, 10);
+
+      expect(result).toEqual(mockResult);
+      expect(result[0].post_diff).toBeGreaterThan(result[1].post_diff);
+    });
+
+    it('limit 만큼의 데이터만 반환해야 한다', async () => {
+      const mockData = [
+        { id: 1, title: 'test' },
+        { id: 2, title: 'test2' },
+        { id: 3, title: 'test3' },
+        { id: 4, title: 'test4' },
+        { id: 5, title: 'test5' },
+      ];
+      const mockLimit = 5;
+
+      mockPool.query.mockResolvedValue({
+        rows: mockData,
+        rowCount: mockData.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('post', 'viewCount', 30, mockLimit);
+
+      expect(result).toEqual(mockData);
+      expect(result.length).toEqual(mockLimit);
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('LIMIT $2'),
+        expect.arrayContaining([30, mockLimit]),
+      );
+    });
+
+    it('type이 post이고 sort가 게시물 수인 경우 조회수를 기준으로 정렬해야 한다.', async () => {
+      const mockResult = [
+        { total_views: 200, total_likes: 5, view_diff: 20, like_diff: 0 },
+        { total_views: 100, total_likes: 50, view_diff: 10, like_diff: 5 },
+      ];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('post', 'postCount', 30, 10);
+
+      expect(result).toEqual(mockResult);
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY view_diff DESC'),
+        expect.anything(),
+      );
+      expect(result[0].view_diff).toBeGreaterThan(result[1].view_diff);
+    });
+
+    it('user 타입에는 GROUP BY 절이 포함되어야 한다', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      } as unknown as QueryResult);
+
+      await repo.getLeaderboard('user', 'viewCount', 30, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('GROUP BY u.id'), expect.anything());
+    });
+
+    it('post 타입에는 GROUP BY 절이 포함되지 않아야 한다', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      } as unknown as QueryResult);
+
+      await repo.getLeaderboard('post', 'viewCount', 30, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expect.not.stringContaining('GROUP BY'), expect.anything());
+    });
+
+    it('dateRange 파라미터가 쿼리에 올바르게 적용되어야 한다', async () => {
+      const mockResult = [{ id: 1 }];
+      const testDateRange = 30;
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      await repo.getLeaderboard('user', 'viewCount', testDateRange, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('$1::int'),
+        expect.arrayContaining([testDateRange, expect.anything()]),
+      );
+    });
+
+    it('유효하지 않은 sort 값이 전달되면 기본값(view_diff)을 사용해야 한다', async () => {
+      const mockResult = [{ view_diff: 10 }];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      await repo.getLeaderboard('user', 'invalidSort', 30, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('view_diff DESC'), expect.anything());
+    });
+
+    it('유효하지 않은 type 값이 전달되면 기본값(user)을 사용해야 한다', async () => {
+      const mockResult = [{ view_diff: 10 }];
+
+      mockPool.query.mockResolvedValue({
+        rows: mockResult,
+        rowCount: mockResult.length,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('invalidType', 'viewCount', 30, 10);
+
+      expect(result).toEqual(mockResult);
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('FROM users_user u'), expect.anything());
+    });
+
+    it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      } as unknown as QueryResult);
+
+      const result = await repo.getLeaderboard('user', 'viewCount', 30, 10);
+
+      expect(result).toEqual([]);
+    });
+
+    it('에러 발생 시 DBError를 던져야 한다', async () => {
+      mockPool.query.mockRejectedValue(new Error('DB connection failed'));
+      await expect(repo.getLeaderboard('post', 'postCount', 30, 10)).rejects.toThrow(DBError);
+    });
+  });
+});

--- a/src/repositories/__test__/leaderboard.repo.test.ts
+++ b/src/repositories/__test__/leaderboard.repo.test.ts
@@ -194,7 +194,7 @@ describe('LeaderboardRepository', () => {
 
       await repo.getLeaderboard('user', 'viewCount', 30, 10);
 
-      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('GROUP BY u.id'), expect.anything());
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('GROUP BY u.id, u.email'), expect.anything());
     });
 
     it('post 타입에는 GROUP BY 절이 포함되지 않아야 한다', async () => {
@@ -223,33 +223,6 @@ describe('LeaderboardRepository', () => {
         expect.stringContaining('$1::int'),
         expect.arrayContaining([testDateRange, expect.anything()]),
       );
-    });
-
-    it('유효하지 않은 sort 값이 전달되면 기본값(view_diff)을 사용해야 한다', async () => {
-      const mockResult = [{ view_diff: 10 }];
-
-      mockPool.query.mockResolvedValue({
-        rows: mockResult,
-        rowCount: mockResult.length,
-      } as unknown as QueryResult);
-
-      await repo.getLeaderboard('user', 'invalidSort', 30, 10);
-
-      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('view_diff DESC'), expect.anything());
-    });
-
-    it('유효하지 않은 type 값이 전달되면 기본값(user)을 사용해야 한다', async () => {
-      const mockResult = [{ view_diff: 10 }];
-
-      mockPool.query.mockResolvedValue({
-        rows: mockResult,
-        rowCount: mockResult.length,
-      } as unknown as QueryResult);
-
-      const result = await repo.getLeaderboard('invalidType', 'viewCount', 30, 10);
-
-      expect(result).toEqual(mockResult);
-      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('FROM users_user u'), expect.anything());
     });
 
     it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -1,33 +1,82 @@
 import logger from '@/configs/logger.config';
 import { Pool } from 'pg';
 import { DBError } from '@/exception';
-import { LeaderboardSortType, LeaderboardType } from '@/types/index';
+import { UserLeaderboardSortType, PostLeaderboardSortType } from '@/types/index';
 
 export class LeaderboardRepository {
   constructor(private pool: Pool) {}
 
-  async getLeaderboard(type: LeaderboardType, sort: LeaderboardSortType, dateRange: number, limit: number) {
+  async getUserLeaderboard(sort: UserLeaderboardSortType, dateRange: number, limit: number) {
     try {
       const cteQuery = this.buildLeaderboardCteQuery();
-      const selectQuery = this.buildLeaderboardSelectQuery(type);
-      const fromClause = this.buildLeaderboardFromClause(type);
-      const sortCol = this.mapSortColByType(sort, type);
-      const groupOrderClause = this.buildLeaderboardGroupOrderClause(sortCol, type);
+      const sortCol = sort === 'postCount' ? 'post_diff' : sort === 'likeCount' ? 'like_diff' : 'view_diff';
 
-      const query = `${cteQuery} ${selectQuery} ${fromClause} ${groupOrderClause}`;
-      const values = await this.pool.query(query, [dateRange, limit]);
+      const query = `
+        ${cteQuery}
+        SELECT
+          u.id AS id,
+          u.email AS email,
+          COALESCE(SUM(ts.today_view), 0) AS total_views,
+          COALESCE(SUM(ts.today_like), 0) AS total_likes, 
+          COUNT(DISTINCT CASE WHEN p.is_active = true THEN p.id END) AS total_posts,
+          SUM(COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0))) AS view_diff,
+          SUM(COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0))) AS like_diff,
+          COUNT(DISTINCT CASE WHEN p.released_at >= CURRENT_DATE - make_interval(days := $1::int) AND p.is_active = true THEN p.id END) AS post_diff
+        FROM users_user u
+        LEFT JOIN posts_post p ON p.user_id = u.id
+        LEFT JOIN today_stats ts ON ts.post_id = p.id
+        LEFT JOIN start_stats ss ON ss.post_id = p.id
+        WHERE u.email IS NOT NULL
+        GROUP BY u.id, u.email
+        ORDER BY ${sortCol} DESC
+        LIMIT $2;
+      `;
+      const result = await this.pool.query(query, [dateRange, limit]);
 
-      return values.rows;
+      return result.rows;
     } catch (error) {
-      logger.error(`Leaderboard Repo getLeaderboard error:`, error);
-      throw new DBError(`${type === 'post' ? '게시글' : '유저'} 리더보드 조회 중 문제가 발생했습니다.`);
+      logger.error(`Leaderboard Repo getUserLeaderboard error:`, error);
+      throw new DBError(`사용자 리더보드 조회 중 문제가 발생했습니다.`);
+    }
+  }
+
+  async getPostLeaderboard(sort: PostLeaderboardSortType, dateRange: number, limit: number) {
+    try {
+      const cteQuery = this.buildLeaderboardCteQuery();
+      const sortCol = sort === 'viewCount' ? 'view_diff' : 'like_diff';
+
+      const query = `
+        ${cteQuery}
+        SELECT
+          p.id AS id,
+          p.title,
+          p.slug,
+          p.released_at,
+          COALESCE(SUM(ts.today_view), 0) AS total_views,
+          COALESCE(SUM(ts.today_like), 0) AS total_likes,
+          COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0)) AS view_diff,
+          COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0)) AS like_diff
+        FROM posts_post p
+        LEFT JOIN today_stats ts ON ts.post_id = p.id
+        LEFT JOIN start_stats ss ON ss.post_id = p.id
+        WHERE p.is_active = true
+        ORDER BY ${sortCol} DESC
+        LIMIT $2;
+      `;
+      const result = await this.pool.query(query, [dateRange, limit]);
+
+      return result.rows;
+    } catch (error) {
+      logger.error(`Leaderboard Repo getPostLeaderboard error:`, error);
+      throw new DBError(`게시물 리더보드 조회 중 문제가 발생했습니다.`);
     }
   }
 
   // 오늘 날짜와 기준 날짜의 통계를 가져오는 CTE(임시 결과 집합) 쿼리 빌드
   private buildLeaderboardCteQuery() {
     return `
-      WITH today_stats AS (
+      WITH 
+      today_stats AS (
         SELECT DISTINCT ON (post_id)
           post_id,
           daily_view_count AS today_view,
@@ -36,121 +85,15 @@ export class LeaderboardRepository {
         WHERE (date AT TIME ZONE 'Asia/Seoul' AT TIME ZONE 'UTC')::date <= (NOW() AT TIME ZONE 'UTC')::date
         ORDER BY post_id, date DESC
       ),
-  
       start_stats AS (
         SELECT DISTINCT ON (post_id)
           post_id,
           daily_view_count AS start_view,
           daily_like_count AS start_like
         FROM posts_postdailystatistics
-        WHERE (date AT TIME ZONE 'Asia/Seoul' AT TIME ZONE 'UTC')::date >= ((NOW() AT TIME ZONE 'UTC')::date - ($1::int * INTERVAL '1 day'))
+        WHERE (date AT TIME ZONE 'Asia/Seoul' AT TIME ZONE 'UTC')::date >= ((NOW() AT TIME ZONE 'UTC')::date - make_interval(days := $1::int))
         ORDER BY post_id, date ASC
       )
     `;
-  }
-
-  // 메인 연산을 포함하는 SELECT 절 빌드
-  private buildLeaderboardSelectQuery(type: LeaderboardType) {
-    if (type === 'post') {
-      return `
-        SELECT
-          p.id AS id,
-          p.title,
-          p.slug,
-          p.released_at,
-
-          -- 총 누적 조회수 / 좋아요 수 (오늘 기준)
-          COALESCE(ts.today_view, 0) AS total_views,
-          COALESCE(ts.today_like, 0) AS total_likes,
-
-          -- 조회수 / 좋아요 수 상승값 = 오늘 - 기준일 (기준일이 없으면 diff = 0)
-          COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0)) AS view_diff,
-          COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0)) AS like_diff
-      `;
-    } else {
-      return `
-        SELECT
-          u.id AS id,
-          u.email AS email,
-
-          -- 전체 게시물 누적 조회수 / 좋아요 수 합계 (오늘 기준)
-          COALESCE(SUM(ts.today_view), 0) AS total_views,
-          COALESCE(SUM(ts.today_like), 0) AS total_likes,
-
-          -- 전체 게시물 조회수 / 좋아요 수 상승값 합계 = 오늘 - 기준일 (기준일이 없으면 diff = 0)
-          SUM(
-            COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0))
-          ) AS view_diff,
-          SUM(
-            COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0))
-          ) AS like_diff,
-
-          -- 최근 dateRange내 업로드된 게시물 수
-          COUNT(DISTINCT CASE
-            WHEN p.released_at >= CURRENT_DATE - $1::int
-            AND p.is_active = true
-            THEN p.id
-          END) AS post_diff,
-
-          -- 전체 활성 게시물 수
-          COUNT(DISTINCT CASE WHEN p.is_active = true THEN p.id END) AS total_posts
-      `;
-    }
-  }
-
-  // CTE 테이블 조인 및 WHERE 절을 포함하는 FROM 절 빌드
-  private buildLeaderboardFromClause(type: LeaderboardType) {
-    if (type === 'post') {
-      return `
-        FROM posts_post p
-        LEFT JOIN today_stats ts ON ts.post_id = p.id
-        LEFT JOIN start_stats ss ON ss.post_id = p.id
-        WHERE p.is_active = true
-      `;
-    } else {
-      return `
-        FROM users_user u
-        LEFT JOIN posts_post p ON p.user_id = u.id
-        LEFT JOIN today_stats ts ON ts.post_id = p.id
-        LEFT JOIN start_stats ss ON ss.post_id = p.id
-        WHERE u.email IS NOT NULL
-      `;
-    }
-  }
-
-  // sort 매개변수를 정렬 컬럼으로 매핑
-  private mapSortColByType(sort: LeaderboardSortType, type: LeaderboardType) {
-    let sortCol = '';
-
-    switch (sort) {
-      case 'postCount':
-        sortCol = type === 'user' ? 'post_diff' : 'view_diff';
-        break;
-      case 'likeCount':
-        sortCol = 'like_diff';
-        break;
-      case 'viewCount':
-      default:
-        sortCol = 'view_diff';
-        break;
-    }
-
-    return sortCol;
-  }
-
-  // 매핑된 정렬 컬럼으로 ORDER BY 절 및 LIMIT 절 빌드
-  private buildLeaderboardGroupOrderClause(sortCol: string, type: LeaderboardType) {
-    if (type === 'post') {
-      return `
-        ORDER BY ${sortCol} DESC
-        LIMIT $2;
-      `;
-    } else {
-      return `
-        GROUP BY u.id, u.email
-        ORDER BY ${sortCol} DESC
-        LIMIT $2;
-      `;
-    }
   }
 }

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -1,5 +1,155 @@
 import { Pool } from 'pg';
+import logger from '@/configs/logger.config';
+import { DBError } from '@/exception';
 
 export class LeaderboardRepository {
   constructor(private pool: Pool) {}
+
+  async getLeaderboard(type: string, sort: string, dateRange: number, limit: number) {
+    try {
+      const cteQuery = this.buildLeaderboardCteQuery();
+      const selectQuery = this.buildLeaderboardSelectQuery(type);
+      const fromClause = this.buildLeaderboardFromClause(type);
+      const sortCol = this.mapSortColByType(sort, type);
+      const groupOrderClause = this.buildLeaderboardGroupOrderClause(sortCol, type);
+
+      const query = `${cteQuery} ${selectQuery} ${fromClause} ${groupOrderClause}`;
+      const values = await this.pool.query(query, [dateRange, limit]);
+
+      return values.rows;
+    } catch (error) {
+      logger.error(`Leaderboard Repo getLeaderboard error:`, error);
+      throw new DBError(`${type === 'user' ? '유저' : '게시글'} 리더보드 조회 중 문제가 발생했습니다.`);
+    }
+  }
+
+  // 오늘 날짜와 기준 날짜의 통계를 가져오는 CTE(임시 결과 집합) 쿼리 빌드
+  private buildLeaderboardCteQuery() {
+    return `
+      WITH today_stats AS (
+        SELECT DISTINCT ON (post_id)
+          post_id,
+          daily_view_count AS today_view,
+          daily_like_count AS today_like
+        FROM posts_postdailystatistics
+        WHERE (date AT TIME ZONE 'Asia/Seoul' AT TIME ZONE 'UTC')::date <= (NOW() AT TIME ZONE 'UTC')::date
+        ORDER BY post_id, date DESC
+      ),
+  
+      start_stats AS (
+        SELECT DISTINCT ON (post_id)
+          post_id,
+          daily_view_count AS start_view,
+          daily_like_count AS start_like
+        FROM posts_postdailystatistics
+        WHERE (date AT TIME ZONE 'Asia/Seoul' AT TIME ZONE 'UTC')::date >= ((NOW() AT TIME ZONE 'UTC')::date - ($1::int * INTERVAL '1 day'))
+        ORDER BY post_id, date ASC
+      )
+    `;
+  }
+
+  // 메인 연산을 포함하는 SELECT 절 빌드
+  private buildLeaderboardSelectQuery(type: string) {
+    if (type === 'post') {
+      return `
+        SELECT
+          p.id AS id,
+          p.title,
+          p.slug,
+          p.released_at,
+
+          -- 총 누적 조회수 / 좋아요 수 (오늘 기준)
+          COALESCE(ts.today_view, 0) AS total_views,
+          COALESCE(ts.today_like, 0) AS total_likes,
+
+          -- 조회수 / 좋아요 수 상승값 = 오늘 - 기준일 (기준일이 없으면 diff = 0)
+          COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0)) AS view_diff,
+          COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0)) AS like_diff
+      `;
+    } else {
+      return `
+        SELECT
+          u.id AS id,
+          u.email AS email,
+
+          -- 전체 게시물 누적 조회수 / 좋아요 수 합계 (오늘 기준)
+          COALESCE(SUM(ts.today_view), 0) AS total_views,
+          COALESCE(SUM(ts.today_like), 0) AS total_likes,
+
+          -- 전체 게시물 조회수 / 좋아요 수 상승값 합계 = 오늘 - 기준일 (기준일이 없으면 diff = 0)
+          SUM(
+            COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0))
+          ) AS view_diff,
+          SUM(
+            COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0))
+          ) AS like_diff,
+
+          -- 최근 dateRange내 업로드된 게시물 수
+          COUNT(DISTINCT CASE
+            WHEN p.released_at >= CURRENT_DATE - $1::int
+            AND p.is_active = true
+            THEN p.id
+          END) AS post_diff,
+
+          -- 전체 활성 게시물 수
+          COUNT(DISTINCT CASE WHEN p.is_active = true THEN p.id END) AS total_posts
+      `;
+    }
+  }
+
+  // CTE 테이블 조인 및 WHERE 절을 포함하는 FROM 절 빌드
+  private buildLeaderboardFromClause(type: string) {
+    if (type === 'post') {
+      return `
+        FROM posts_post p
+        LEFT JOIN today_stats ts ON ts.post_id = p.id
+        LEFT JOIN start_stats ss ON ss.post_id = p.id
+        WHERE p.is_active = true
+      `;
+    } else {
+      return `
+        FROM users_user u
+        LEFT JOIN posts_post p ON p.user_id = u.id
+        LEFT JOIN today_stats ts ON ts.post_id = p.id
+        LEFT JOIN start_stats ss ON ss.post_id = p.id
+        WHERE u.email IS NOT NULL
+      `;
+    }
+  }
+
+  // sort 매개변수를 정렬 컬럼으로 매핑
+  private mapSortColByType(sort: string, type: string) {
+    let sortCol = '';
+
+    switch (sort) {
+      case 'postCount':
+        sortCol = type === 'user' ? 'post_diff' : 'view_diff';
+        break;
+      case 'likeCount':
+        sortCol = 'like_diff';
+        break;
+      case 'viewCount':
+      default:
+        sortCol = 'view_diff';
+        break;
+    }
+
+    return sortCol;
+  }
+
+  // 매핑된 정렬 컬럼으로 ORDER BY 절 및 LIMIT 절 빌드
+  private buildLeaderboardGroupOrderClause(sortCol: string, type: string) {
+    if (type === 'post') {
+      return `
+        ORDER BY ${sortCol} DESC
+        LIMIT $2;
+      `;
+    } else {
+      return `
+        GROUP BY u.id
+        ORDER BY ${sortCol} DESC
+        LIMIT $2;
+      `;
+    }
+  }
 }

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -19,7 +19,7 @@ export class LeaderboardRepository {
       return values.rows;
     } catch (error) {
       logger.error(`Leaderboard Repo getLeaderboard error:`, error);
-      throw new DBError(`${type === 'user' ? '유저' : '게시글'} 리더보드 조회 중 문제가 발생했습니다.`);
+      throw new DBError(`${type === 'post' ? '게시글' : '유저'} 리더보드 조회 중 문제가 발생했습니다.`);
     }
   }
 

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -1,0 +1,5 @@
+import { Pool } from 'pg';
+
+export class LeaderboardRepository {
+  constructor(private pool: Pool) {}
+}

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -1,7 +1,7 @@
-import { Pool } from 'pg';
 import logger from '@/configs/logger.config';
+import { Pool } from 'pg';
 import { DBError } from '@/exception';
-import { LeaderboardSortType, LeaderboardType } from '@/types/dto/requests/getLeaderboardQuery.type';
+import { LeaderboardSortType, LeaderboardType } from '@/types/index';
 
 export class LeaderboardRepository {
   constructor(private pool: Pool) {}

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -9,7 +9,6 @@ export class LeaderboardRepository {
   async getUserLeaderboard(sort: UserLeaderboardSortType, dateRange: number, limit: number) {
     try {
       const cteQuery = this.buildLeaderboardCteQuery();
-      const sortCol = sort === 'postCount' ? 'post_diff' : sort === 'likeCount' ? 'like_diff' : 'view_diff';
 
       const query = `
         ${cteQuery}
@@ -28,7 +27,7 @@ export class LeaderboardRepository {
         LEFT JOIN start_stats ss ON ss.post_id = p.id
         WHERE u.email IS NOT NULL
         GROUP BY u.id, u.email
-        ORDER BY ${sortCol} DESC
+        ORDER BY ${this.SORT_COL_MAPPING[sort]} DESC
         LIMIT $2;
       `;
       const result = await this.pool.query(query, [dateRange, limit]);
@@ -43,7 +42,6 @@ export class LeaderboardRepository {
   async getPostLeaderboard(sort: PostLeaderboardSortType, dateRange: number, limit: number) {
     try {
       const cteQuery = this.buildLeaderboardCteQuery();
-      const sortCol = sort === 'viewCount' ? 'view_diff' : 'like_diff';
 
       const query = `
         ${cteQuery}
@@ -60,7 +58,7 @@ export class LeaderboardRepository {
         LEFT JOIN today_stats ts ON ts.post_id = p.id
         LEFT JOIN start_stats ss ON ss.post_id = p.id
         WHERE p.is_active = true
-        ORDER BY ${sortCol} DESC
+        ORDER BY ${this.SORT_COL_MAPPING[sort]} DESC
         LIMIT $2;
       `;
       const result = await this.pool.query(query, [dateRange, limit]);
@@ -96,4 +94,10 @@ export class LeaderboardRepository {
       )
     `;
   }
+
+  private readonly SORT_COL_MAPPING = {
+    viewCount: 'view_diff',
+    likeCount: 'like_diff',
+    postCount: 'post_diff',
+  } as const;
 }

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -1,11 +1,12 @@
 import { Pool } from 'pg';
 import logger from '@/configs/logger.config';
 import { DBError } from '@/exception';
+import { LeaderboardSortType, LeaderboardType } from '@/types/dto/requests/getLeaderboardQuery.type';
 
 export class LeaderboardRepository {
   constructor(private pool: Pool) {}
 
-  async getLeaderboard(type: string, sort: string, dateRange: number, limit: number) {
+  async getLeaderboard(type: LeaderboardType, sort: LeaderboardSortType, dateRange: number, limit: number) {
     try {
       const cteQuery = this.buildLeaderboardCteQuery();
       const selectQuery = this.buildLeaderboardSelectQuery(type);
@@ -49,7 +50,7 @@ export class LeaderboardRepository {
   }
 
   // 메인 연산을 포함하는 SELECT 절 빌드
-  private buildLeaderboardSelectQuery(type: string) {
+  private buildLeaderboardSelectQuery(type: LeaderboardType) {
     if (type === 'post') {
       return `
         SELECT
@@ -98,7 +99,7 @@ export class LeaderboardRepository {
   }
 
   // CTE 테이블 조인 및 WHERE 절을 포함하는 FROM 절 빌드
-  private buildLeaderboardFromClause(type: string) {
+  private buildLeaderboardFromClause(type: LeaderboardType) {
     if (type === 'post') {
       return `
         FROM posts_post p
@@ -118,7 +119,7 @@ export class LeaderboardRepository {
   }
 
   // sort 매개변수를 정렬 컬럼으로 매핑
-  private mapSortColByType(sort: string, type: string) {
+  private mapSortColByType(sort: LeaderboardSortType, type: LeaderboardType) {
     let sortCol = '';
 
     switch (sort) {
@@ -138,7 +139,7 @@ export class LeaderboardRepository {
   }
 
   // 매핑된 정렬 컬럼으로 ORDER BY 절 및 LIMIT 절 빌드
-  private buildLeaderboardGroupOrderClause(sortCol: string, type: string) {
+  private buildLeaderboardGroupOrderClause(sortCol: string, type: LeaderboardType) {
     if (type === 'post') {
       return `
         ORDER BY ${sortCol} DESC
@@ -146,7 +147,7 @@ export class LeaderboardRepository {
       `;
     } else {
       return `
-        GROUP BY u.id
+        GROUP BY u.id, u.email
         ORDER BY ${sortCol} DESC
         LIMIT $2;
       `;

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -52,8 +52,8 @@ export class LeaderboardRepository {
           p.title,
           p.slug,
           p.released_at,
-          COALESCE(SUM(ts.today_view), 0) AS total_views,
-          COALESCE(SUM(ts.today_like), 0) AS total_likes,
+          COALESCE(ts.today_view, 0) AS total_views,
+          COALESCE(ts.today_like, 0) AS total_likes,
           COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0)) AS view_diff,
           COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0)) AS like_diff
         FROM posts_post p

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,6 +2,7 @@ import express, { Router } from 'express';
 import UserRouter from './user.router';
 import PostRouter from './post.router';
 import NotiRouter from './noti.router';
+import LeaderboardRouter from './leaderboard.router';
 
 const router: Router = express.Router();
 
@@ -12,4 +13,5 @@ router.use('/ping', (req, res) => {
 router.use('/', UserRouter);
 router.use('/', PostRouter);
 router.use('/', NotiRouter);
+router.use('/', LeaderboardRouter);
 export default router;

--- a/src/routes/leaderboard.router.ts
+++ b/src/routes/leaderboard.router.ts
@@ -1,0 +1,51 @@
+import express, { Router } from 'express';
+import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
+import pool from '@/configs/db.config';
+import { LeaderboardService } from '@/services/leaderboard.service';
+import { LeaderboardController } from '@/controllers/leaderboard.controller';
+import { validateRequestDto } from '@/middlewares/validation.middleware';
+import { GetLeaderboardQueryDto } from '@/types/dto/requests/getLeaderboardQuery.type';
+
+const router: Router = express.Router();
+
+const leaderboardRepository = new LeaderboardRepository(pool);
+const leaderboardService = new LeaderboardService(leaderboardRepository);
+const leaderboardController = new LeaderboardController(leaderboardService);
+
+/**
+ * @swagger
+ * /leaderboard:
+ *   get:
+ *     summary: 리더보드 조회
+ *     tags:
+ *       - Leaderboard
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/type'
+ *       - in: query
+ *         name: sort
+ *         schema:
+ *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/sort'
+ *       - in: query
+ *         name: dateRange
+ *         schema:
+ *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/dateRange'
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/limit'
+ *     responses:
+ *       '200':
+ *         description: 리더보드 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/LeaderboardResponseDto'
+ *       '500':
+ *         description: 서버 오류 / 데이터 베이스 조회 오류
+ */
+router.get('/leaderboard', validateRequestDto(GetLeaderboardQueryDto, 'query'), leaderboardController.getLeaderboard);
+
+export default router;

--- a/src/routes/leaderboard.router.ts
+++ b/src/routes/leaderboard.router.ts
@@ -1,10 +1,10 @@
+import pool from '@/configs/db.config';
 import express, { Router } from 'express';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
-import pool from '@/configs/db.config';
 import { LeaderboardService } from '@/services/leaderboard.service';
 import { LeaderboardController } from '@/controllers/leaderboard.controller';
 import { validateRequestDto } from '@/middlewares/validation.middleware';
-import { GetLeaderboardQueryDto } from '@/types/dto/requests/getLeaderboardQuery.type';
+import { GetUserLeaderboardQueryDto, GetPostLeaderboardQueryDto } from '@/types/dto/requests/getLeaderboardQuery.type';
 
 const router: Router = express.Router();
 
@@ -14,20 +14,16 @@ const leaderboardController = new LeaderboardController(leaderboardService);
 
 /**
  * @swagger
- * /leaderboard:
+ * /leaderboard/user:
  *   get:
- *     summary: 리더보드 조회
+ *     summary: 사용자 리더보드 조회
  *     tags:
  *       - Leaderboard
  *     parameters:
  *       - in: query
- *         name: type
- *         schema:
- *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/type'
- *       - in: query
  *         name: sort
  *         schema:
- *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/sort'
+ *           $ref: '#/components/schemas/UserLeaderboardSortType'
  *       - in: query
  *         name: dateRange
  *         schema:
@@ -38,14 +34,54 @@ const leaderboardController = new LeaderboardController(leaderboardService);
  *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/limit'
  *     responses:
  *       '200':
- *         description: 리더보드 조회 성공
+ *         description: 사용자 리더보드 조회 성공
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/LeaderboardResponseDto'
+ *               $ref: '#/components/schemas/UserLeaderboardResponseDto'
  *       '500':
  *         description: 서버 오류 / 데이터 베이스 조회 오류
  */
-router.get('/leaderboard', validateRequestDto(GetLeaderboardQueryDto, 'query'), leaderboardController.getLeaderboard);
+router.get(
+  '/leaderboard/user',
+  validateRequestDto(GetUserLeaderboardQueryDto, 'query'),
+  leaderboardController.getUserLeaderboard,
+);
+
+/**
+ * @swagger
+ * /leaderboard/post:
+ *   get:
+ *     summary: 게시물 리더보드 조회
+ *     tags:
+ *       - Leaderboard
+ *     parameters:
+ *       - in: query
+ *         name: sort
+ *         schema:
+ *           $ref: '#/components/schemas/PostLeaderboardSortType'
+ *       - in: query
+ *         name: dateRange
+ *         schema:
+ *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/dateRange'
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           $ref: '#/components/schemas/GetLeaderboardQueryDto/properties/limit'
+ *     responses:
+ *       '200':
+ *         description: 게시물 리더보드 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PostLeaderboardResponseDto'
+ *       '500':
+ *         description: 서버 오류 / 데이터 베이스 조회 오류
+ */
+router.get(
+  '/leaderboard/post',
+  validateRequestDto(GetPostLeaderboardQueryDto, 'query'),
+  leaderboardController.getPostLeaderboard,
+);
 
 export default router;

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -50,7 +50,6 @@ describe('LeaderboardService', () => {
       ];
 
       const mockResult = {
-        posts: null,
         users: [
           {
             id: 1,
@@ -76,13 +75,22 @@ describe('LeaderboardService', () => {
       };
 
       repo.getUserLeaderboard.mockResolvedValue(mockRawResult);
-      const result = await service.getUserLeaderboard();
+      const result = await service.getUserLeaderboard('viewCount', 30, 10);
 
       expect(result.users).toEqual(mockResult.users);
     });
 
+    it('쿼리 파라미터가 올바르게 적용되어야 한다', async () => {
+      repo.getUserLeaderboard.mockResolvedValue([]);
+
+      await service.getUserLeaderboard('postCount', 30, 10);
+
+      expect(repo.getUserLeaderboard).toHaveBeenCalledWith('postCount', 30, 10);
+    });
+
     it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
       repo.getUserLeaderboard.mockResolvedValue([]);
+
       await service.getUserLeaderboard();
 
       expect(repo.getUserLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
@@ -90,6 +98,7 @@ describe('LeaderboardService', () => {
 
     it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
       repo.getUserLeaderboard.mockResolvedValue([]);
+
       const result = await service.getUserLeaderboard();
 
       expect(result).toEqual({ users: [] });
@@ -153,17 +162,25 @@ describe('LeaderboardService', () => {
             releasedAt: '2025-01-02',
           },
         ],
-        users: null,
       };
 
       repo.getPostLeaderboard.mockResolvedValue(mockRawResult);
-      const result = await service.getPostLeaderboard();
+      const result = await service.getPostLeaderboard('viewCount', 30, 10);
 
       expect(result.posts).toEqual(mockResult.posts);
     });
 
+    it('쿼리 파라미터가 올바르게 적용되어야 한다', async () => {
+      repo.getPostLeaderboard.mockResolvedValue([]);
+
+      await service.getPostLeaderboard('likeCount', 30, 10);
+
+      expect(repo.getPostLeaderboard).toHaveBeenCalledWith('likeCount', 30, 10);
+    });
+
     it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
       repo.getPostLeaderboard.mockResolvedValue([]);
+
       await service.getPostLeaderboard();
 
       expect(repo.getPostLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -1,7 +1,7 @@
+import { Pool } from 'pg';
 import { DBError } from '@/exception';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
 import { LeaderboardService } from '@/services/leaderboard.service';
-import { Pool } from 'pg';
 
 jest.mock('@/repositories/leaderboard.repository');
 

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -148,6 +148,13 @@ describe('LeaderboardService', () => {
       expect(repo.getLeaderboard).toHaveBeenCalledWith('user', 'viewCount', 30, 10);
     });
 
+    it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
+      repo.getLeaderboard.mockResolvedValue([]);
+      const result = await service.getLeaderboard();
+
+      expect(result).toEqual({ users: [], posts: null });
+    });
+
     it('쿼리 오류 발생 시 예외를 그대로 전파한다', async () => {
       const errorMessage = '유저 리더보드 조회 중 문제가 발생했습니다.';
       const dbError = new DBError(errorMessage);

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -28,7 +28,7 @@ describe('LeaderboardService', () => {
     it('응답 형식에 맞게 변환된 사용자 리더보드 데이터를 반환해야 한다', async () => {
       const mockRawResult = [
         {
-          id: 1,
+          id: '1',
           email: 'test@test.com',
           total_views: 100,
           total_likes: 50,
@@ -38,7 +38,7 @@ describe('LeaderboardService', () => {
           post_diff: 1,
         },
         {
-          id: 2,
+          id: '2',
           email: 'test2@test.com',
           total_views: 200,
           total_likes: 100,
@@ -52,7 +52,7 @@ describe('LeaderboardService', () => {
       const mockResult = {
         users: [
           {
-            id: 1,
+            id: '1',
             email: 'test@test.com',
             totalViews: 100,
             totalLikes: 50,
@@ -62,7 +62,7 @@ describe('LeaderboardService', () => {
             postDiff: 1,
           },
           {
-            id: 2,
+            id: '2',
             email: 'test2@test.com',
             totalViews: 200,
             totalLikes: 100,
@@ -118,7 +118,7 @@ describe('LeaderboardService', () => {
     it('응답 형식에 맞게 변환된 게시물 리더보드 데이터를 반환해야 한다', async () => {
       const mockRawResult = [
         {
-          id: 1,
+          id: '1',
           title: 'test',
           slug: 'test-slug',
           total_views: 100,
@@ -128,7 +128,7 @@ describe('LeaderboardService', () => {
           released_at: '2025-01-01',
         },
         {
-          id: 2,
+          id: '2',
           title: 'test2',
           slug: 'test2-slug',
           total_views: 200,
@@ -142,7 +142,7 @@ describe('LeaderboardService', () => {
       const mockResult = {
         posts: [
           {
-            id: 1,
+            id: '1',
             title: 'test',
             slug: 'test-slug',
             totalViews: 100,
@@ -152,7 +152,7 @@ describe('LeaderboardService', () => {
             releasedAt: '2025-01-01',
           },
           {
-            id: 2,
+            id: '2',
             title: 'test2',
             slug: 'test2-slug',
             totalViews: 200,

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -1,0 +1,160 @@
+import { DBError } from '@/exception';
+import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
+import { LeaderboardService } from '@/services/leaderboard.service';
+import { Pool } from 'pg';
+
+jest.mock('@/repositories/leaderboard.repository');
+
+describe('LeaderboardService', () => {
+  let service: LeaderboardService;
+  let repo: jest.Mocked<LeaderboardRepository>;
+  let mockPool: jest.Mocked<Pool>;
+
+  beforeEach(() => {
+    const mockPoolObj = {};
+    mockPool = mockPoolObj as jest.Mocked<Pool>;
+
+    const repoInstance = new LeaderboardRepository(mockPool);
+    repo = repoInstance as jest.Mocked<LeaderboardRepository>;
+
+    service = new LeaderboardService(repo);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLeaderboard', () => {
+    it('type이 user인 경우 posts는 null이고, users는 응답 형식에 맞게 변환되어야 한다', async () => {
+      const mockRawResult = [
+        {
+          id: 1,
+          email: 'test@test.com',
+          total_views: 100,
+          total_likes: 50,
+          total_posts: 1,
+          view_diff: 20,
+          like_diff: 10,
+          post_diff: 1,
+        },
+        {
+          id: 2,
+          email: 'test2@test.com',
+          total_views: 200,
+          total_likes: 100,
+          total_posts: 2,
+          view_diff: 10,
+          like_diff: 5,
+          post_diff: 1,
+        },
+      ];
+
+      const mockResult = {
+        posts: null,
+        users: [
+          {
+            id: 1,
+            email: 'test@test.com',
+            totalViews: 100,
+            totalLikes: 50,
+            totalPosts: 1,
+            viewDiff: 20,
+            likeDiff: 10,
+            postDiff: 1,
+          },
+          {
+            id: 2,
+            email: 'test2@test.com',
+            totalViews: 200,
+            totalLikes: 100,
+            totalPosts: 2,
+            viewDiff: 10,
+            likeDiff: 5,
+            postDiff: 1,
+          },
+        ],
+      };
+
+      repo.getLeaderboard.mockResolvedValue(mockRawResult);
+
+      const result = await service.getLeaderboard('user');
+
+      expect(result.posts).toBeNull();
+      expect(result.users).toEqual(mockResult.users);
+    });
+
+    it('type이 post인 경우 users는 null이고, posts는 응답 형식에 맞게 변환되어야 한다', async () => {
+      const mockRawResult = [
+        {
+          id: 1,
+          title: 'test',
+          slug: 'test-slug',
+          total_views: 100,
+          total_likes: 50,
+          view_diff: 20,
+          like_diff: 10,
+          released_at: '2025-01-01',
+        },
+        {
+          id: 2,
+          title: 'test2',
+          slug: 'test2-slug',
+          total_views: 200,
+          total_likes: 100,
+          view_diff: 10,
+          like_diff: 5,
+          released_at: '2025-01-02',
+        },
+      ];
+
+      const mockResult = {
+        posts: [
+          {
+            id: 1,
+            title: 'test',
+            slug: 'test-slug',
+            totalViews: 100,
+            totalLikes: 50,
+            viewDiff: 20,
+            likeDiff: 10,
+            releasedAt: '2025-01-01',
+          },
+          {
+            id: 2,
+            title: 'test2',
+            slug: 'test2-slug',
+            totalViews: 200,
+            totalLikes: 100,
+            viewDiff: 10,
+            likeDiff: 5,
+            releasedAt: '2025-01-02',
+          },
+        ],
+        users: null,
+      };
+
+      repo.getLeaderboard.mockResolvedValue(mockRawResult);
+
+      const result = await service.getLeaderboard('post');
+
+      expect(result.users).toBeNull();
+      expect(result.posts).toEqual(mockResult.posts);
+    });
+
+    it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
+      repo.getLeaderboard.mockResolvedValue([]);
+      await service.getLeaderboard();
+
+      expect(repo.getLeaderboard).toHaveBeenCalledWith('user', 'viewCount', 30, 10);
+    });
+
+    it('쿼리 오류 발생 시 예외를 그대로 전파한다', async () => {
+      const errorMessage = '유저 리더보드 조회 중 문제가 발생했습니다.';
+      const dbError = new DBError(errorMessage);
+      repo.getLeaderboard.mockRejectedValue(dbError);
+
+      await expect(service.getLeaderboard()).rejects.toThrow(errorMessage);
+      expect(repo.getLeaderboard).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -24,8 +24,8 @@ describe('LeaderboardService', () => {
     jest.clearAllMocks();
   });
 
-  describe('getLeaderboard', () => {
-    it('type이 user인 경우 posts는 null이고, users는 응답 형식에 맞게 변환되어야 한다', async () => {
+  describe('getUserLeaderboard', () => {
+    it('응답 형식에 맞게 변환된 사용자 리더보드 데이터를 반환해야 한다', async () => {
       const mockRawResult = [
         {
           id: 1,
@@ -75,15 +75,38 @@ describe('LeaderboardService', () => {
         ],
       };
 
-      repo.getLeaderboard.mockResolvedValue(mockRawResult);
+      repo.getUserLeaderboard.mockResolvedValue(mockRawResult);
+      const result = await service.getUserLeaderboard();
 
-      const result = await service.getLeaderboard('user');
-
-      expect(result.posts).toBeNull();
       expect(result.users).toEqual(mockResult.users);
     });
 
-    it('type이 post인 경우 users는 null이고, posts는 응답 형식에 맞게 변환되어야 한다', async () => {
+    it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
+      repo.getUserLeaderboard.mockResolvedValue([]);
+      await service.getUserLeaderboard();
+
+      expect(repo.getUserLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
+    });
+
+    it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
+      repo.getUserLeaderboard.mockResolvedValue([]);
+      const result = await service.getUserLeaderboard();
+
+      expect(result).toEqual({ users: [] });
+    });
+
+    it('쿼리 오류 발생 시 예외를 그대로 전파한다', async () => {
+      const errorMessage = '사용자 리더보드 조회 중 문제가 발생했습니다.';
+      const dbError = new DBError(errorMessage);
+      repo.getUserLeaderboard.mockRejectedValue(dbError);
+
+      await expect(service.getUserLeaderboard()).rejects.toThrow(errorMessage);
+      expect(repo.getUserLeaderboard).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getPostLeaderboard', () => {
+    it('응답 형식에 맞게 변환된 게시물 리더보드 데이터를 반환해야 한다', async () => {
       const mockRawResult = [
         {
           id: 1,
@@ -133,35 +156,33 @@ describe('LeaderboardService', () => {
         users: null,
       };
 
-      repo.getLeaderboard.mockResolvedValue(mockRawResult);
+      repo.getPostLeaderboard.mockResolvedValue(mockRawResult);
+      const result = await service.getPostLeaderboard();
 
-      const result = await service.getLeaderboard('post');
-
-      expect(result.users).toBeNull();
       expect(result.posts).toEqual(mockResult.posts);
     });
 
     it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
-      repo.getLeaderboard.mockResolvedValue([]);
-      await service.getLeaderboard();
+      repo.getPostLeaderboard.mockResolvedValue([]);
+      await service.getPostLeaderboard();
 
-      expect(repo.getLeaderboard).toHaveBeenCalledWith('user', 'viewCount', 30, 10);
+      expect(repo.getPostLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
     });
 
     it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
-      repo.getLeaderboard.mockResolvedValue([]);
-      const result = await service.getLeaderboard();
+      repo.getPostLeaderboard.mockResolvedValue([]);
+      const result = await service.getPostLeaderboard();
 
-      expect(result).toEqual({ users: [], posts: null });
+      expect(result).toEqual({ posts: [] });
     });
 
     it('쿼리 오류 발생 시 예외를 그대로 전파한다', async () => {
-      const errorMessage = '유저 리더보드 조회 중 문제가 발생했습니다.';
+      const errorMessage = '게시물 리더보드 조회 중 문제가 발생했습니다.';
       const dbError = new DBError(errorMessage);
-      repo.getLeaderboard.mockRejectedValue(dbError);
+      repo.getPostLeaderboard.mockRejectedValue(dbError);
 
-      await expect(service.getLeaderboard()).rejects.toThrow(errorMessage);
-      expect(repo.getLeaderboard).toHaveBeenCalledTimes(1);
+      await expect(service.getPostLeaderboard()).rejects.toThrow(errorMessage);
+      expect(repo.getPostLeaderboard).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -1,11 +1,12 @@
 import logger from '@/configs/logger.config';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
-import { LeaderboardSortType, LeaderboardType } from '@/types/dto/requests/getLeaderboardQuery.type';
 import {
-  LeaderboardPostType,
   LeaderboardResponseData,
-  LeaderboardUserType,
-} from '@/types/dto/responses/leaderboardResponse.type';
+  LeaderboardType,
+  LeaderboardSortType,
+  LeaderboardUserTypeData,
+  LeaderboardPostTypeData,
+} from '@/types/index';
 
 export class LeaderboardService {
   constructor(private leaderboardRepo: LeaderboardRepository) {}
@@ -35,7 +36,7 @@ export class LeaderboardService {
 
     if (type === 'post') {
       result.posts = (rawResult as RawPostResult[]).map(
-        (post): LeaderboardPostType => ({
+        (post): LeaderboardPostTypeData => ({
           id: post.id,
           title: post.title,
           slug: post.slug,
@@ -48,7 +49,7 @@ export class LeaderboardService {
       );
     } else {
       result.users = (rawResult as RawUserResult[]).map(
-        (user): LeaderboardUserType => ({
+        (user): LeaderboardUserTypeData => ({
           id: user.id,
           email: user.email,
           totalViews: user.total_views,

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -1,5 +1,6 @@
 import logger from '@/configs/logger.config';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
+import { LeaderboardSortType, LeaderboardType } from '@/types/dto/requests/getLeaderboardQuery.type';
 import {
   LeaderboardPostType,
   LeaderboardResponseData,
@@ -10,8 +11,8 @@ export class LeaderboardService {
   constructor(private leaderboardRepo: LeaderboardRepository) {}
 
   async getLeaderboard(
-    type: string = 'user',
-    sort: string = 'viewCount',
+    type: LeaderboardType = 'user',
+    sort: LeaderboardSortType = 'viewCount',
     dateRange: number = 30,
     limit: number = 10,
   ): Promise<LeaderboardResponseData> {
@@ -26,7 +27,10 @@ export class LeaderboardService {
     }
   }
 
-  private mapRawResultToLeaderboardResponseData(rawResult: unknown[], type: string): LeaderboardResponseData {
+  private mapRawResultToLeaderboardResponseData(
+    rawResult: RawPostResult[] | RawUserResult[],
+    type: LeaderboardType,
+  ): LeaderboardResponseData {
     const result: LeaderboardResponseData = { posts: null, users: null };
 
     if (type === 'post') {
@@ -60,7 +64,6 @@ export class LeaderboardService {
     return result;
   }
 }
-
 interface RawPostResult {
   id: number;
   title: string;

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -70,7 +70,7 @@ export class LeaderboardService {
 }
 
 interface RawPostResult {
-  id: number;
+  id: string;
   title: string;
   slug: string;
   total_views: number;
@@ -81,7 +81,7 @@ interface RawPostResult {
 }
 
 interface RawUserResult {
-  id: number;
+  id: string;
   email: string;
   total_views: number;
   total_likes: number;

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -1,0 +1,5 @@
+import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
+
+export class LeaderboardService {
+  constructor(private leaderboardRepo: LeaderboardRepository) {}
+}

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -1,5 +1,54 @@
+import logger from '@/configs/logger.config';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
+import { LeaderboardResponseData } from '@/types/dto/responses/leaderboardResponse.type';
 
 export class LeaderboardService {
   constructor(private leaderboardRepo: LeaderboardRepository) {}
+
+  async getLeaderboard(
+    type: string = 'user',
+    sort: string = 'viewCount',
+    dateRange: number = 30,
+    limit: number = 10,
+  ): Promise<LeaderboardResponseData> {
+    try {
+      const rawResult = await this.leaderboardRepo.getLeaderboard(type, sort, dateRange, limit);
+      const result = this.mapRawResultToLeaderboardResponseData(rawResult, type);
+
+      return result;
+    } catch (error) {
+      logger.error('LeaderboardService getLeaderboard error : ', error);
+      throw error;
+    }
+  }
+
+  private mapRawResultToLeaderboardResponseData(rawResult: unknown[], type: string): LeaderboardResponseData {
+    const result = { posts: null, users: null };
+
+    if (type === 'post') {
+      result.posts = rawResult.map((post) => ({
+        id: post.id,
+        title: post.title,
+        slug: post.slug,
+        totalViews: post.total_views,
+        totalLikes: post.total_likes,
+        viewDiff: post.view_diff,
+        likeDiff: post.like_diff,
+        releasedAt: post.released_at,
+      }));
+    } else {
+      result.users = rawResult.map((user) => ({
+        id: user.id,
+        email: user.email,
+        totalViews: user.total_views,
+        totalLikes: user.total_likes,
+        totalPosts: user.total_posts,
+        viewDiff: user.view_diff,
+        likeDiff: user.like_diff,
+        postDiff: user.post_diff,
+      }));
+    }
+
+    return result;
+  }
 }

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -1,6 +1,10 @@
 import logger from '@/configs/logger.config';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
-import { LeaderboardResponseData } from '@/types/dto/responses/leaderboardResponse.type';
+import {
+  LeaderboardPostType,
+  LeaderboardResponseData,
+  LeaderboardUserType,
+} from '@/types/dto/responses/leaderboardResponse.type';
 
 export class LeaderboardService {
   constructor(private leaderboardRepo: LeaderboardRepository) {}
@@ -23,32 +27,58 @@ export class LeaderboardService {
   }
 
   private mapRawResultToLeaderboardResponseData(rawResult: unknown[], type: string): LeaderboardResponseData {
-    const result = { posts: null, users: null };
+    const result: LeaderboardResponseData = { posts: null, users: null };
 
     if (type === 'post') {
-      result.posts = rawResult.map((post) => ({
-        id: post.id,
-        title: post.title,
-        slug: post.slug,
-        totalViews: post.total_views,
-        totalLikes: post.total_likes,
-        viewDiff: post.view_diff,
-        likeDiff: post.like_diff,
-        releasedAt: post.released_at,
-      }));
+      result.posts = (rawResult as RawPostResult[]).map(
+        (post): LeaderboardPostType => ({
+          id: post.id,
+          title: post.title,
+          slug: post.slug,
+          totalViews: post.total_views,
+          totalLikes: post.total_likes,
+          viewDiff: post.view_diff,
+          likeDiff: post.like_diff,
+          releasedAt: post.released_at,
+        }),
+      );
     } else {
-      result.users = rawResult.map((user) => ({
-        id: user.id,
-        email: user.email,
-        totalViews: user.total_views,
-        totalLikes: user.total_likes,
-        totalPosts: user.total_posts,
-        viewDiff: user.view_diff,
-        likeDiff: user.like_diff,
-        postDiff: user.post_diff,
-      }));
+      result.users = (rawResult as RawUserResult[]).map(
+        (user): LeaderboardUserType => ({
+          id: user.id,
+          email: user.email,
+          totalViews: user.total_views,
+          totalLikes: user.total_likes,
+          totalPosts: user.total_posts,
+          viewDiff: user.view_diff,
+          likeDiff: user.like_diff,
+          postDiff: user.post_diff,
+        }),
+      );
     }
 
     return result;
   }
+}
+
+interface RawPostResult {
+  id: number;
+  title: string;
+  slug: string;
+  total_views: number;
+  total_likes: number;
+  view_diff: number;
+  like_diff: number;
+  released_at: string;
+}
+
+interface RawUserResult {
+  id: number;
+  email: string;
+  total_views: number;
+  total_likes: number;
+  total_posts: number;
+  view_diff: number;
+  like_diff: number;
+  post_diff: number;
 }

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -1,70 +1,74 @@
 import logger from '@/configs/logger.config';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
 import {
-  LeaderboardResponseData,
-  LeaderboardType,
-  LeaderboardSortType,
-  LeaderboardUserTypeData,
-  LeaderboardPostTypeData,
+  UserLeaderboardSortType,
+  PostLeaderboardSortType,
+  UserLeaderboardData,
+  PostLeaderboardData,
 } from '@/types/index';
 
 export class LeaderboardService {
   constructor(private leaderboardRepo: LeaderboardRepository) {}
 
-  async getLeaderboard(
-    type: LeaderboardType = 'user',
-    sort: LeaderboardSortType = 'viewCount',
+  async getUserLeaderboard(
+    sort: UserLeaderboardSortType = 'viewCount',
     dateRange: number = 30,
     limit: number = 10,
-  ): Promise<LeaderboardResponseData> {
+  ): Promise<UserLeaderboardData> {
     try {
-      const rawResult = await this.leaderboardRepo.getLeaderboard(type, sort, dateRange, limit);
-      const result = this.mapRawResultToLeaderboardResponseData(rawResult, type);
-
-      return result;
+      const rawResult = await this.leaderboardRepo.getUserLeaderboard(sort, dateRange, limit);
+      return this.mapRawUserResult(rawResult);
     } catch (error) {
-      logger.error('LeaderboardService getLeaderboard error : ', error);
+      logger.error('LeaderboardService getUserLeaderboard error : ', error);
       throw error;
     }
   }
 
-  private mapRawResultToLeaderboardResponseData(
-    rawResult: RawPostResult[] | RawUserResult[],
-    type: LeaderboardType,
-  ): LeaderboardResponseData {
-    const result: LeaderboardResponseData = { posts: null, users: null };
-
-    if (type === 'post') {
-      result.posts = (rawResult as RawPostResult[]).map(
-        (post): LeaderboardPostTypeData => ({
-          id: post.id,
-          title: post.title,
-          slug: post.slug,
-          totalViews: post.total_views,
-          totalLikes: post.total_likes,
-          viewDiff: post.view_diff,
-          likeDiff: post.like_diff,
-          releasedAt: post.released_at,
-        }),
-      );
-    } else {
-      result.users = (rawResult as RawUserResult[]).map(
-        (user): LeaderboardUserTypeData => ({
-          id: user.id,
-          email: user.email,
-          totalViews: user.total_views,
-          totalLikes: user.total_likes,
-          totalPosts: user.total_posts,
-          viewDiff: user.view_diff,
-          likeDiff: user.like_diff,
-          postDiff: user.post_diff,
-        }),
-      );
+  async getPostLeaderboard(
+    sort: PostLeaderboardSortType = 'viewCount',
+    dateRange: number = 30,
+    limit: number = 10,
+  ): Promise<PostLeaderboardData> {
+    try {
+      const rawResult = await this.leaderboardRepo.getPostLeaderboard(sort, dateRange, limit);
+      return this.mapRawPostResult(rawResult);
+    } catch (error) {
+      logger.error('LeaderboardService getPostLeaderboard error : ', error);
+      throw error;
     }
+  }
 
-    return result;
+  private mapRawUserResult(rawResult: RawUserResult[]): UserLeaderboardData {
+    const users = rawResult.map((user) => ({
+      id: user.id,
+      email: user.email,
+      totalViews: user.total_views,
+      totalLikes: user.total_likes,
+      totalPosts: user.total_posts,
+      viewDiff: user.view_diff,
+      likeDiff: user.like_diff,
+      postDiff: user.post_diff,
+    }));
+
+    return { users };
+  }
+
+  private mapRawPostResult(rawResult: RawPostResult[]): PostLeaderboardData {
+    const posts = rawResult.map((post) => ({
+      id: post.id,
+      title: post.title,
+      slug: post.slug,
+      totalViews: post.total_views,
+      totalLikes: post.total_likes,
+      viewDiff: post.view_diff,
+      likeDiff: post.like_diff,
+      releasedAt: post.released_at,
+    }));
+
+    return { posts };
   }
 }
+
 interface RawPostResult {
   id: number;
   title: string;

--- a/src/types/dto/requests/getLeaderboardQuery.type.ts
+++ b/src/types/dto/requests/getLeaderboardQuery.type.ts
@@ -5,33 +5,39 @@ import { IsEnum, IsNumber, IsOptional, Max, Min } from 'class-validator';
  * @swagger
  * components:
  *   schemas:
- *     LeaderboardType:
+ *     UserLeaderboardSortType:
  *       type: string
- *       description: 리더보드 조회 타입
+ *       description: 사용자 리더보드 정렬 기준
  *       nullable: true
- *       enum: ['user', 'post']
- *       default: 'user'
+ *       enum: ['viewCount', 'likeCount', 'postCount']
+ *       default: 'viewCount'
  */
-export type LeaderboardType = 'user' | 'post';
+export type UserLeaderboardSortType = 'viewCount' | 'likeCount' | 'postCount';
 
 /**
  * @swagger
  * components:
  *   schemas:
- *     LeaderboardSortType:
+ *     PostLeaderboardSortType:
  *       type: string
- *       description: 리더보드 정렬 기준
+ *       description: 게시물 리더보드 정렬 기준
  *       nullable: true
- *       enum: ['viewCount', 'likeCount', 'postCount']
+ *       enum: ['viewCount', 'likeCount']
  *       default: 'viewCount'
  */
-export type LeaderboardSortType = 'viewCount' | 'likeCount' | 'postCount';
+export type PostLeaderboardSortType = 'viewCount' | 'likeCount';
 
-export interface GetLeaderboardQuery {
-  type?: LeaderboardType;
-  sort?: LeaderboardSortType;
+interface GetLeaderboardQuery {
   dateRange?: number;
   limit?: number;
+}
+
+export interface GetUserLeaderboardQuery extends GetLeaderboardQuery {
+  sort?: UserLeaderboardSortType;
+}
+
+export interface GetPostLeaderboardQuery extends GetLeaderboardQuery {
+  sort?: PostLeaderboardSortType;
 }
 
 /**
@@ -41,16 +47,6 @@ export interface GetLeaderboardQuery {
  *     GetLeaderboardQueryDto:
  *       type: object
  *       properties:
- *         type:
- *           $ref: '#/components/schemas/LeaderboardType'
- *           description: 리더보드 조회 타입
- *           nullable: true
- *           default: 'user'
- *         sort:
- *           $ref: '#/components/schemas/LeaderboardSortType'
- *           description: 리더보드 정렬 기준
- *           nullable: true
- *           default: 'viewCount'
  *         dateRange:
  *           type: number
  *           description: 리더보드 조회 기간 (일수)
@@ -66,35 +62,75 @@ export interface GetLeaderboardQuery {
  *           minimum: 1
  *           maximum: 30
  */
-export class GetLeaderboardQueryDto {
-  @IsOptional()
-  @IsEnum(['user', 'post'])
-  @Transform(({ value }) => (value === '' ? 'user' : value))
-  type?: LeaderboardType;
-
-  @IsOptional()
-  @IsEnum(['viewCount', 'likeCount', 'postCount'])
-  @Transform(({ value }) => (value === '' ? 'viewCount' : value))
-  sort?: LeaderboardSortType;
-
+class GetLeaderboardQueryDto {
   @IsOptional()
   @IsNumber()
-  @Transform(({ value }) => Number(value))
+  @Transform(({ value }) => (value === '' ? 30 : Number(value)))
   @Min(1)
   @Max(30)
   dateRange?: number;
 
   @IsOptional()
   @IsNumber()
-  @Transform(({ value }) => Number(value))
+  @Transform(({ value }) => (value === '' ? 10 : Number(value)))
   @Min(1)
   @Max(30)
   limit?: number;
 
-  constructor(type?: LeaderboardType, sort?: LeaderboardSortType, dateRange?: number, limit?: number) {
-    this.type = type;
-    this.sort = sort;
+  constructor(dateRange?: number, limit?: number) {
     this.dateRange = dateRange;
     this.limit = limit;
+  }
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     GetUserLeaderboardQueryDto:
+ *       type: object
+ *       properties:
+ *         sort:
+ *           type: string
+ *           description: 사용자 리더보드 정렬 기준
+ *           nullable: true
+ *           enum: ['viewCount', 'likeCount', 'postCount']
+ *           default: 'viewCount'
+ */
+export class GetUserLeaderboardQueryDto extends GetLeaderboardQueryDto {
+  @IsOptional()
+  @IsEnum(['viewCount', 'likeCount', 'postCount'])
+  @Transform(({ value }) => (value === '' ? 'viewCount' : value))
+  sort?: UserLeaderboardSortType;
+
+  constructor(sort?: UserLeaderboardSortType) {
+    super();
+    this.sort = sort;
+  }
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     GetPostLeaderboardQueryDto:
+ *       type: object
+ *       properties:
+ *         sort:
+ *           type: string
+ *           description: 게시물 리더보드 정렬 기준
+ *           nullable: true
+ *           enum: ['viewCount', 'likeCount']
+ *           default: 'viewCount'
+ */
+export class GetPostLeaderboardQueryDto extends GetLeaderboardQueryDto {
+  @IsOptional()
+  @IsEnum(['viewCount', 'likeCount'])
+  @Transform(({ value }) => (value === '' ? 'viewCount' : value))
+  sort?: PostLeaderboardSortType;
+
+  constructor(sort?: PostLeaderboardSortType) {
+    super();
+    this.sort = sort;
   }
 }

--- a/src/types/dto/requests/getLeaderboardQuery.type.ts
+++ b/src/types/dto/requests/getLeaderboardQuery.type.ts
@@ -1,0 +1,98 @@
+import { Transform } from 'class-transformer';
+import { IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardType:
+ *       type: string
+ *       description: 리더보드 조회 타입
+ *       nullable: true
+ *       enum: ['user', 'post']
+ *       default: 'user'
+ */
+export type LeaderboardType = 'user' | 'post';
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardSortType:
+ *       type: string
+ *       description: 리더보드 정렬 기준
+ *       nullable: true
+ *       enum: ['viewCount', 'likeCount', 'postCount']
+ *       default: 'viewCount'
+ */
+export type LeaderboardSortType = 'viewCount' | 'likeCount' | 'postCount';
+
+export interface GetLeaderboardQuery {
+  type?: LeaderboardType;
+  sort?: LeaderboardSortType;
+  dateRange?: number;
+  limit?: number;
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     GetLeaderboardQueryDto:
+ *       type: object
+ *       properties:
+ *         type:
+ *           $ref: '#/components/schemas/LeaderboardType'
+ *           description: 리더보드 조회 타입
+ *           nullable: true
+ *           default: 'user'
+ *         sort:
+ *           $ref: '#/components/schemas/LeaderboardSortType'
+ *           description: 리더보드 정렬 기준
+ *           nullable: true
+ *           default: 'viewCount'
+ *         dateRange:
+ *           type: number
+ *           description: 리더보드 조회 기간 (일수)
+ *           nullable: true
+ *           default: 30
+ *           minimum: 1
+ *           maximum: 30
+ *         limit:
+ *           type: number
+ *           description: 리더보드 조회 제한 수
+ *           nullable: true
+ *           default: 10
+ *           minimum: 1
+ *           maximum: 30
+ */
+export class GetLeaderboardQueryDto {
+  @IsOptional()
+  @IsString()
+  type?: LeaderboardType;
+
+  @IsOptional()
+  @IsString()
+  sort?: LeaderboardSortType;
+
+  @IsOptional()
+  @IsNumber()
+  @Transform(({ value }) => Number(value))
+  @Min(1)
+  @Max(30)
+  dateRange?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Transform(({ value }) => Number(value))
+  @Min(1)
+  @Max(30)
+  limit?: number;
+
+  constructor(type?: LeaderboardType, sort?: LeaderboardSortType, dateRange?: number, limit?: number) {
+    this.type = type;
+    this.sort = sort;
+    this.dateRange = dateRange;
+    this.limit = limit;
+  }
+}

--- a/src/types/dto/requests/getLeaderboardQuery.type.ts
+++ b/src/types/dto/requests/getLeaderboardQuery.type.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, Max, Min } from 'class-validator';
 
 /**
  * @swagger
@@ -68,11 +68,13 @@ export interface GetLeaderboardQuery {
  */
 export class GetLeaderboardQueryDto {
   @IsOptional()
-  @IsString()
+  @IsEnum(['user', 'post'])
+  @Transform(({ value }) => (value === '' ? 'user' : value))
   type?: LeaderboardType;
 
   @IsOptional()
-  @IsString()
+  @IsEnum(['viewCount', 'likeCount', 'postCount'])
+  @Transform(({ value }) => (value === '' ? 'viewCount' : value))
   sort?: LeaderboardSortType;
 
   @IsOptional()

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -4,7 +4,7 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  * @swagger
  * components:
  *   schemas:
- *     LeaderboardUserType:
+ *     LeaderboardUser:
  *       type: object
  *       properties:
  *         id:
@@ -32,7 +32,7 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  *           type: integer
  *           description: 구간 게시물 수 상승값
  */
-export interface LeaderboardUserTypeData {
+interface LeaderboardUser {
   id: number;
   email: string;
   totalViews: number;
@@ -47,7 +47,38 @@ export interface LeaderboardUserTypeData {
  * @swagger
  * components:
  *   schemas:
- *     LeaderboardPostType:
+ *     UserLeaderboardData:
+ *       type: object
+ *       properties:
+ *         users:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             $ref: '#/components/schemas/LeaderboardUser'
+ */
+export interface UserLeaderboardData {
+  users: LeaderboardUser[];
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     UserLeaderboardResponseDto:
+ *       allOf:
+ *         - $ref: '#/components/schemas/BaseResponseDto'
+ *         - type: object
+ *           properties:
+ *             data:
+ *               $ref: '#/components/schemas/UserLeaderboardData'
+ */
+export class UserLeaderboardResponseDto extends BaseResponseDto<UserLeaderboardData> {}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardPost:
  *       type: object
  *       properties:
  *         id:
@@ -76,7 +107,7 @@ export interface LeaderboardUserTypeData {
  *           format: date-time
  *           description: 게시물 업로드 일시
  */
-export interface LeaderboardPostTypeData {
+interface LeaderboardPost {
   id: number;
   title: string;
   slug: string;
@@ -91,35 +122,29 @@ export interface LeaderboardPostTypeData {
  * @swagger
  * components:
  *   schemas:
- *     LeaderboardResponseData:
+ *     PostLeaderboardData:
  *       type: object
  *       properties:
  *         posts:
  *           type: array
  *           nullable: true
  *           items:
- *             $ref: '#/components/schemas/LeaderboardPostType'
- *         users:
- *           type: array
- *           nullable: true
- *           items:
- *             $ref: '#/components/schemas/LeaderboardUserType'
+ *             $ref: '#/components/schemas/LeaderboardPost'
  */
-export interface LeaderboardResponseData {
-  users: LeaderboardUserTypeData[] | null;
-  posts: LeaderboardPostTypeData[] | null;
+export interface PostLeaderboardData {
+  posts: LeaderboardPost[];
 }
 
 /**
  * @swagger
  * components:
  *   schemas:
- *     LeaderboardResponseDto:
+ *     PostLeaderboardResponseDto:
  *       allOf:
  *         - $ref: '#/components/schemas/BaseResponseDto'
  *         - type: object
  *           properties:
  *             data:
- *               $ref: '#/components/schemas/LeaderboardResponseData'
+ *               $ref: '#/components/schemas/PostLeaderboardData'
  */
-export class LeaderboardResponseDto extends BaseResponseDto<LeaderboardResponseData> {}
+export class PostLeaderboardResponseDto extends BaseResponseDto<PostLeaderboardData> {}

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -1,0 +1,125 @@
+import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardUserType:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *           description: 사용자 ID
+ *         email:
+ *           type: string
+ *           description: 사용자 이메일
+ *         totalViews:
+ *           type: integer
+ *           description: 누적 조회수
+ *         totalLikes:
+ *           type: integer
+ *           description: 누적 좋아요 수
+ *         totalPosts:
+ *           type: integer
+ *           description: 누적 게시물 수
+ *         viewDiff:
+ *           type: integer
+ *           description: 구간 조회수 상승값
+ *         likeDiff:
+ *           type: integer
+ *           description: 구간 좋아요 수 상승값
+ *         postDiff:
+ *           type: integer
+ *           description: 구간 게시물 수 상승값
+ */
+export interface LeaderboardUserType {
+  id: number;
+  email: string;
+  totalViews: number;
+  totalLikes: number;
+  totalPosts: number;
+  viewDiff: number;
+  likeDiff: number;
+  postDiff: number;
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardPostType:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *           description: 게시물 ID
+ *         title:
+ *           type: string
+ *           description: 게시물 제목
+ *         slug:
+ *           type: string
+ *           description: 게시물 url slug 값
+ *         totalViews:
+ *           type: integer
+ *           description: 누적 조회수
+ *         totalLikes:
+ *           type: integer
+ *           description: 누적 좋아요 수
+ *         viewDiff:
+ *           type: integer
+ *           description: 구간 조회수 상승값
+ *         likeDiff:
+ *           type: integer
+ *           description: 구간 좋아요 수 상승값
+ *         releasedAt:
+ *           type: string
+ *           format: date-time
+ *           description: 게시물 업로드 일시
+ */
+export interface LeaderboardPostType {
+  id: number;
+  title: string;
+  slug: string;
+  totalViews: number;
+  totalLikes: number;
+  viewDiff: number;
+  likeDiff: number;
+  releasedAt: string;
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardResponseData:
+ *       type: object
+ *       properties:
+ *         posts:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             $ref: '#/components/schemas/LeaderboardPostType'
+ *         users:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             $ref: '#/components/schemas/LeaderboardUserType'
+ */
+export interface LeaderboardResponseData {
+  users: LeaderboardUserType[] | null;
+  posts: LeaderboardPostType[] | null;
+}
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     LeaderboardResponseDto:
+ *       allOf:
+ *         - $ref: '#/components/schemas/BaseResponseDto'
+ *         - type: object
+ *           properties:
+ *             data:
+ *               $ref: '#/components/schemas/LeaderboardResponseData'
+ */
+export class LeaderboardResponseDto extends BaseResponseDto<LeaderboardResponseData> {}

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -32,7 +32,7 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  *           type: integer
  *           description: 구간 게시물 수 상승값
  */
-export interface LeaderboardUserType {
+export interface LeaderboardUserTypeData {
   id: number;
   email: string;
   totalViews: number;
@@ -76,7 +76,7 @@ export interface LeaderboardUserType {
  *           format: date-time
  *           description: 게시물 업로드 일시
  */
-export interface LeaderboardPostType {
+export interface LeaderboardPostTypeData {
   id: number;
   title: string;
   slug: string;
@@ -106,8 +106,8 @@ export interface LeaderboardPostType {
  *             $ref: '#/components/schemas/LeaderboardUserType'
  */
 export interface LeaderboardResponseData {
-  users: LeaderboardUserType[] | null;
-  posts: LeaderboardPostType[] | null;
+  users: LeaderboardUserTypeData[] | null;
+  posts: LeaderboardPostTypeData[] | null;
 }
 
 /**

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -8,8 +8,8 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  *       type: object
  *       properties:
  *         id:
- *           type: integer
- *           description: 사용자 ID
+ *           type: string
+ *           description: 사용자 PK
  *         email:
  *           type: string
  *           description: 사용자 이메일
@@ -33,7 +33,7 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  *           description: 구간 게시물 수 상승값
  */
 interface LeaderboardUser {
-  id: number;
+  id: string;
   email: string;
   totalViews: number;
   totalLikes: number;
@@ -81,8 +81,8 @@ export class UserLeaderboardResponseDto extends BaseResponseDto<UserLeaderboardD
  *       type: object
  *       properties:
  *         id:
- *           type: integer
- *           description: 게시물 ID
+ *           type: string
+ *           description: 게시물 PK
  *         title:
  *           type: string
  *           description: 게시물 제목
@@ -107,7 +107,7 @@ export class UserLeaderboardResponseDto extends BaseResponseDto<UserLeaderboardD
  *           description: 게시물 업로드 일시
  */
 interface LeaderboardPost {
-  id: number;
+  id: string;
   title: string;
   slug: string;
   totalViews: number;

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -52,7 +52,6 @@ interface LeaderboardUser {
  *       properties:
  *         users:
  *           type: array
- *           nullable: true
  *           items:
  *             $ref: '#/components/schemas/LeaderboardUser'
  */
@@ -127,7 +126,6 @@ interface LeaderboardPost {
  *       properties:
  *         posts:
  *           type: array
- *           nullable: true
  *           items:
  *             $ref: '#/components/schemas/LeaderboardPost'
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,12 @@ export type { GetPostQuery, PostParam } from '@/types/dto/requests/getPostQuery.
 
 export { GetAllPostsQueryDto } from '@/types/dto/requests/getAllPostsQuery.type';
 export { GetPostQueryDto } from '@/types/dto/requests/getPostQuery.type';
+export {
+  GetLeaderboardQueryDto,
+  LeaderboardType,
+  LeaderboardSortType,
+  GetLeaderboardQuery,
+} from '@/types/dto/requests/getLeaderboardQuery.type';
 export { LoginResponseDto } from '@/types/dto/responses/loginResponse.type';
 export { EmptyResponseDto } from '@/types/dto/responses/emptyReponse.type';
 export {
@@ -16,5 +22,11 @@ export {
   PostStatisticsResponseDto,
   RawPostType,
 } from '@/types/dto/responses/postResponse.type';
+export {
+  LeaderboardResponseDto,
+  LeaderboardUserTypeData,
+  LeaderboardPostTypeData,
+  LeaderboardResponseData,
+} from '@/types/dto/responses/leaderboardResponse.type';
 export { UserWithTokenDto } from '@/types/dto/userWithToken.type';
 export { VelogUserLoginDto } from '@/types/dto/velogUser.type';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,10 +9,12 @@ export type { GetPostQuery, PostParam } from '@/types/dto/requests/getPostQuery.
 export { GetAllPostsQueryDto } from '@/types/dto/requests/getAllPostsQuery.type';
 export { GetPostQueryDto } from '@/types/dto/requests/getPostQuery.type';
 export {
-  GetLeaderboardQueryDto,
-  LeaderboardType,
-  LeaderboardSortType,
-  GetLeaderboardQuery,
+  GetUserLeaderboardQueryDto,
+  GetPostLeaderboardQueryDto,
+  GetUserLeaderboardQuery,
+  GetPostLeaderboardQuery,
+  UserLeaderboardSortType,
+  PostLeaderboardSortType,
 } from '@/types/dto/requests/getLeaderboardQuery.type';
 export { LoginResponseDto } from '@/types/dto/responses/loginResponse.type';
 export { EmptyResponseDto } from '@/types/dto/responses/emptyReponse.type';
@@ -23,10 +25,10 @@ export {
   RawPostType,
 } from '@/types/dto/responses/postResponse.type';
 export {
-  LeaderboardResponseDto,
-  LeaderboardUserTypeData,
-  LeaderboardPostTypeData,
-  LeaderboardResponseData,
+  UserLeaderboardResponseDto,
+  PostLeaderboardResponseDto,
+  UserLeaderboardData,
+  PostLeaderboardData,
 } from '@/types/dto/responses/leaderboardResponse.type';
 export { UserWithTokenDto } from '@/types/dto/userWithToken.type';
 export { VelogUserLoginDto } from '@/types/dto/velogUser.type';


### PR DESCRIPTION
## 🔥 변경 사항

- **Leaderboard 조회 API 구현**
- Leaderboard 도메인 파일을 각 계층에 추가
- Leaderboard 조회 관련 타입 추가
- 서비스, 리포지토리 계층 단위 테스트 코드 추가

참고사항
- `startDateViews` 를 제공하는 대신 서버에서 미리 상승값을 계산해 (`viewGrowth` 처럼) 보내는 것으로 수정하였습니다. (스웨거 또는 노션 참고)
- 오늘날짜의 데이터와 기준날짜의 데이터를 사용하는 대신, 오늘날짜에서 가장 최근값(`값 <= 오늘날짜`)과 기준날짜에서 가장 최근값(`값 >= 기준날짜`)를 사용하도록 했습니다.

## 🏷 관련 이슈

없습니다!

## 📸 스크린샷 (UI 변경 시 필수)

UI 변경 사항 없습니다!

## 📌 체크리스트
- [ ] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)

기능 테스트는 약간 세모입니다...
단위 테스트 커버리지는 100이고, GPT로 더미 데이터를 만들어 넣어서 스웨거로 테스트 해보았고 로컬에선 잘 작동했는데요.
운영 DB는 데이터가 방대해서 어떻게 될 지 확신하기가 두렵네요. [현우님의 이 PR](https://github.com/Check-Data-Out/velog-dashboard-v2-back-office/pull/26)이 머지되고 로컬DB로 데이터 마이그레이션 후 테스트 통과한다면 맘 놓을 수 있을 것 같아요. 다른 테스트 방법이 있다면 알려주시면 감사하겠습니다...😸 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - `/leaderboard/user` 및 `/leaderboard/post` 엔드포인트를 추가하여 사용자 및 게시글 리더보드를 조회할 수 있습니다.
    - 조회 시 정렬 기준(조회수, 좋아요 수, 게시글 수), 기간(최대 30일), 반환 개수 등을 쿼리 파라미터로 지원합니다.
    - 리더보드 결과에 누적 조회수, 좋아요 수, 게시글 수 및 기간별 증감 정보가 포함됩니다.

- **문서화**
    - 리더보드 API에 대한 Swagger 문서가 추가되어 요청/응답 형식, 쿼리 파라미터, 응답 예시 등을 확인할 수 있습니다.

- **테스트**
    - 리더보드 서비스와 저장소에 대한 단위 테스트가 추가되어 다양한 조회 조건과 예외 상황을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->