### PR TITLE
hotfix: QR 토큰 생성 시 UUID 타입 오류 해결

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -118,7 +118,7 @@ export class UserController {
       const ip = typeof req.headers['x-forwarded-for'] === 'string' ? req.headers['x-forwarded-for'].split(',')[0].trim() : req.ip ?? '';
       const userAgent = req.headers['user-agent'] || '';
 
-      const token = await this.userService.create(user.id, ip, userAgent);
+      const token = await this.userService.create(user.velog_uuid, ip, userAgent);
       const typedToken = token as Token10;
 
       const response = new QRLoginTokenResponseDto(
@@ -147,7 +147,7 @@ export class UserController {
       }
       
       const { decryptedAccessToken, decryptedRefreshToken } = 
-        await this.userService.findUserAndTokensByVelogUUID(found.user.toString());
+        await this.userService.findUserAndTokensByVelogUUID(String(found.user));
 
       res.clearCookie('access_token', this.cookieOption());
       res.clearCookie('refresh_token', this.cookieOption());

--- a/src/services/__test__/qr.service.test.ts
+++ b/src/services/__test__/qr.service.test.ts
@@ -61,7 +61,7 @@ describe('UserService 의 QRService', () => {
     });
     
     it('유저 조회 실패 시 예외 발생', async () => {
-      repo.findByUserVelogUUID.mockResolvedValueOnce(null as any);
+      repo.findByUserVelogUUID.mockResolvedValueOnce(null as unknown as typeof mockUser);
       
       await expect(service.create(velogUUID, ip, userAgent)).rejects.toThrow('QR 토큰 생성 실패: 유저 없음');
     });
@@ -70,7 +70,7 @@ describe('UserService 의 QRService', () => {
       repo.findByUserVelogUUID.mockResolvedValueOnce(mockUser);
       repo.createQRLoginToken.mockRejectedValueOnce(new DBError('생성 실패'));
 
-      await expect(service.create('uuid-1234', 'ip', 'agent')).rejects.toThrow('생성 실패');
+      await expect(service.create(velogUUID, ip, userAgent)).rejects.toThrow('생성 실패');
     });
   });
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -136,9 +136,14 @@ export class UserService {
     return { user, decryptedAccessToken, decryptedRefreshToken };
   }
 
-  async create(userId: number, ip: string, userAgent: string): Promise<string> {
+  async create(velogUUID: string, ip: string, userAgent: string): Promise<string> {
+    const user = await this.userRepo.findByUserVelogUUID(velogUUID);
+    if (!user) {
+      throw new NotFoundError('QR 토큰 생성 실패: 유저 없음');
+    }
+
     const token = generateRandomToken(10);
-    await this.userRepo.createQRLoginToken(token, userId, ip, userAgent);
+    await this.userRepo.createQRLoginToken(token, user.id, ip, userAgent);
     return token;
   }
 


### PR DESCRIPTION
## 🔥 변경 사항
- authMiddleware에서 UUID 기반 사용자 정보 전달
- service 내에서 UUID로 유저 조회 후, bigint id로 토큰 생성되도록 변경

## 🏷 관련 이슈
- 관련 이슈: `#123`

## 📸 스크린샷 (UI 변경 시 필수)
(변경 사항이 UI와 관련된 경우 스크린샷을 첨부해주세요.)

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - QR 토큰 생성 시 사용자 식별에 velogUUID를 사용하도록 개선하여 사용자 조회 및 예외 처리가 보다 정확하게 동작합니다.
  - 사용자 토큰 생성 및 조회 과정에서 velogUUID를 명시적으로 사용하도록 변경하여 일관성을 높였습니다.

- **테스트**
  - QR 토큰 생성 서비스 테스트가 velogUUID 기반으로 변경되었으며, 사용자 미존재 및 토큰 생성 실패 상황에 대한 테스트가 추가되었습니다.

- **공개 메서드 변경**
  - QR 토큰 생성 메서드의 입력값이 userId에서 velogUUID로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->