### PR TITLE
[25.06.27 / TASK-210] Feature - 리더보드 username 대응 개발

### DIFF
--- a/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
+++ b/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
@@ -105,6 +105,7 @@ describe('LeaderboardRepository 통합 테스트', () => {
       result.forEach((leaderboardUser) => {
         expect(leaderboardUser).toHaveProperty('id');
         expect(leaderboardUser).toHaveProperty('email');
+        expect(leaderboardUser).toHaveProperty('username');
         expect(leaderboardUser).toHaveProperty('total_views');
         expect(leaderboardUser).toHaveProperty('total_likes');
         expect(leaderboardUser).toHaveProperty('total_posts');
@@ -214,13 +215,13 @@ describe('LeaderboardRepository 통합 테스트', () => {
       }
     });
 
-    it('email이 null인 사용자는 제외되어야 한다', async () => {
+    it('username이 null인 사용자는 제외되어야 한다', async () => {
       const result = await repo.getUserLeaderboard(DEFAULT_PARAMS.USER_SORT, DEFAULT_PARAMS.DATE_RANGE, 30);
 
-      if (!isEnoughData(result, 1, '사용자 리더보드 email null 제외')) return;
+      if (!isEnoughData(result, 1, '사용자 리더보드 username null 제외')) return;
 
       result.forEach((user) => {
-        expect(user.email).not.toBeNull();
+        expect(user.username).not.toBeNull();
       });
     });
   });
@@ -241,6 +242,7 @@ describe('LeaderboardRepository 통합 테스트', () => {
         expect(leaderboardPost).toHaveProperty('id');
         expect(leaderboardPost).toHaveProperty('title');
         expect(leaderboardPost).toHaveProperty('slug');
+        expect(leaderboardPost).toHaveProperty('username');
         expect(leaderboardPost).toHaveProperty('total_views');
         expect(leaderboardPost).toHaveProperty('total_likes');
         expect(leaderboardPost).toHaveProperty('view_diff');

--- a/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
+++ b/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
@@ -12,7 +12,7 @@ import { PostLeaderboardSortType, UserLeaderboardSortType } from '@/types';
 
 dotenv.config();
 
-jest.setTimeout(20000); // 각 케이스당 20초 타임아웃 설정
+jest.setTimeout(60000); // 각 케이스당 60초 타임아웃 설정
 
 /**
  * LeaderboardRepository 통합 테스트
@@ -44,7 +44,7 @@ describe('LeaderboardRepository 통합 테스트', () => {
         idleTimeoutMillis: 30000, // 연결 유휴 시간 (30초)
         connectionTimeoutMillis: 5000, // 연결 시간 초과 (5초)
         allowExitOnIdle: false, // 유휴 상태에서 종료 허용
-        statement_timeout: 30000,
+        statement_timeout: 60000, // 쿼리 타임아웃 증가 (60초)
       };
 
       // localhost 가 아니면 ssl 필수

--- a/src/repositories/__test__/leaderboard.repo.test.ts
+++ b/src/repositories/__test__/leaderboard.repo.test.ts
@@ -6,7 +6,6 @@ import { mockPool, createMockQueryResult } from '@/utils/fixtures';
 
 jest.mock('pg');
 
-
 describe('LeaderboardRepository', () => {
   let repo: LeaderboardRepository;
 
@@ -20,6 +19,7 @@ describe('LeaderboardRepository', () => {
         {
           id: '1',
           email: 'test@test.com',
+          username: 'test',
           total_views: 100,
           total_likes: 50,
           total_posts: 1,
@@ -30,6 +30,7 @@ describe('LeaderboardRepository', () => {
         {
           id: '2',
           email: 'test2@test.com',
+          username: 'test2',
           total_views: 200,
           total_likes: 100,
           total_posts: 2,
@@ -79,7 +80,7 @@ describe('LeaderboardRepository', () => {
 
       expect(mockPool.query).toHaveBeenCalledWith(
         expect.stringContaining('WHERE date >='), // pastDateKST를 사용하는 부분 확인
-        [expect.any(Number)] // limit
+        [expect.any(Number)], // limit
       );
     });
 
@@ -96,6 +97,7 @@ describe('LeaderboardRepository', () => {
           id: '2',
           title: 'test2',
           slug: 'test2',
+          username: 'test2',
           total_views: 200,
           total_likes: 100,
           view_diff: 20,
@@ -106,6 +108,7 @@ describe('LeaderboardRepository', () => {
           id: '1',
           title: 'test',
           slug: 'test',
+          username: 'test',
           total_views: 100,
           total_likes: 50,
           view_diff: 10,
@@ -154,7 +157,7 @@ describe('LeaderboardRepository', () => {
 
       expect(mockPool.query).toHaveBeenCalledWith(
         expect.stringContaining('WHERE date >='), // pastDateKST를 사용하는 부분 확인
-        [expect.any(Number)] // limit
+        [expect.any(Number)], // limit
       );
     });
 

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -17,6 +17,7 @@ export class LeaderboardRepository {
         SELECT
           u.id AS id,
           u.email AS email,
+          u.username AS username,
           COALESCE(SUM(ts.today_view), 0) AS total_views,
           COALESCE(SUM(ts.today_like), 0) AS total_likes, 
           COUNT(DISTINCT CASE WHEN p.is_active = true THEN p.id END) AS total_posts,
@@ -27,8 +28,8 @@ export class LeaderboardRepository {
         LEFT JOIN posts_post p ON p.user_id = u.id
         LEFT JOIN today_stats ts ON ts.post_id = p.id
         LEFT JOIN start_stats ss ON ss.post_id = p.id
-        WHERE u.email IS NOT NULL
-        GROUP BY u.id, u.email
+        WHERE u.username IS NOT NULL
+        GROUP BY u.id, u.email, u.username
         ORDER BY ${this.SORT_COL_MAPPING[sort]} DESC, u.id
         LIMIT $1;
       `;
@@ -52,11 +53,13 @@ export class LeaderboardRepository {
           p.title,
           p.slug,
           p.released_at,
+          u.username AS username,
           COALESCE(ts.today_view, 0) AS total_views,
           COALESCE(ts.today_like, 0) AS total_likes,
           COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, COALESCE(ts.today_view, 0)) AS view_diff,
           COALESCE(ts.today_like, 0) - COALESCE(ss.start_like, COALESCE(ts.today_like, 0)) AS like_diff
         FROM posts_post p
+        LEFT JOIN users_user u ON u.id = p.user_id
         LEFT JOIN today_stats ts ON ts.post_id = p.id
         LEFT JOIN start_stats ss ON ss.post_id = p.id
         WHERE p.is_active = true

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -30,6 +30,7 @@ describe('LeaderboardService', () => {
         {
           id: '1',
           email: 'test@test.com',
+          username: 'test',
           total_views: '100',
           total_likes: '50',
           total_posts: '1',
@@ -40,6 +41,7 @@ describe('LeaderboardService', () => {
         {
           id: '2',
           email: 'test2@test.com',
+          username: 'test2',
           total_views: '200',
           total_likes: '100',
           total_posts: '2',
@@ -54,6 +56,7 @@ describe('LeaderboardService', () => {
           {
             id: '1',
             email: 'test@test.com',
+            username: 'test',
             totalViews: 100,
             totalLikes: 50,
             totalPosts: 1,
@@ -64,6 +67,7 @@ describe('LeaderboardService', () => {
           {
             id: '2',
             email: 'test2@test.com',
+            username: 'test2',
             totalViews: 200,
             totalLikes: 100,
             totalPosts: 2,
@@ -121,6 +125,7 @@ describe('LeaderboardService', () => {
           id: '1',
           title: 'test',
           slug: 'test-slug',
+          username: 'test',
           total_views: '100',
           total_likes: '50',
           view_diff: '20',
@@ -131,6 +136,7 @@ describe('LeaderboardService', () => {
           id: '2',
           title: 'test2',
           slug: 'test2-slug',
+          username: 'test2',
           total_views: '200',
           total_likes: '100',
           view_diff: '10',
@@ -145,6 +151,7 @@ describe('LeaderboardService', () => {
             id: '1',
             title: 'test',
             slug: 'test-slug',
+            username: 'test',
             totalViews: 100,
             totalLikes: 50,
             viewDiff: 20,
@@ -155,6 +162,7 @@ describe('LeaderboardService', () => {
             id: '2',
             title: 'test2',
             slug: 'test2-slug',
+            username: 'test2',
             totalViews: 200,
             totalLikes: 100,
             viewDiff: 10,

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -74,7 +74,7 @@ export class LeaderboardService {
 interface RawUserResult {
   id: string;
   email: string | null;
-  username: string | null;
+  username: string;
   total_views: string;
   total_likes: string;
   total_posts: string;

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -41,7 +41,8 @@ export class LeaderboardService {
   private mapRawUserResult(rawResult: RawUserResult[]): UserLeaderboardData {
     const users = rawResult.map((user) => ({
       id: user.id,
-      email: user.email,
+      email: user.email || null,
+      username: user.username,
       totalViews: Number(user.total_views),
       totalLikes: Number(user.total_likes),
       totalPosts: Number(user.total_posts),
@@ -58,6 +59,7 @@ export class LeaderboardService {
       id: post.id,
       title: post.title,
       slug: post.slug,
+      username: post.username || null,
       totalViews: Number(post.total_views),
       totalLikes: Number(post.total_likes),
       viewDiff: Number(post.view_diff),
@@ -69,24 +71,26 @@ export class LeaderboardService {
   }
 }
 
-interface RawPostResult {
-  id: string;
-  title: string;
-  slug: string;
-  total_views: string;
-  total_likes: string;
-  view_diff: string;
-  like_diff: string;
-  released_at: string;
-}
-
 interface RawUserResult {
   id: string;
-  email: string;
+  email: string | null;
+  username: string | null;
   total_views: string;
   total_likes: string;
   total_posts: string;
   view_diff: string;
   like_diff: string;
   post_diff: string;
+}
+
+interface RawPostResult {
+  id: string;
+  title: string;
+  slug: string;
+  username: string | null;
+  total_views: string;
+  total_likes: string;
+  view_diff: string;
+  like_diff: string;
+  released_at: string;
 }

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -13,6 +13,11 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  *         email:
  *           type: string
  *           description: 사용자 이메일
+ *           nullable: true
+ *         username:
+ *           type: string
+ *           nullable: true
+ *           description: 사용자 이름
  *         totalViews:
  *           type: integer
  *           description: 누적 조회수
@@ -34,7 +39,8 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  */
 interface LeaderboardUser {
   id: string;
-  email: string;
+  email: string | null;
+  username: string | null;
   totalViews: number;
   totalLikes: number;
   totalPosts: number;
@@ -89,6 +95,10 @@ export class UserLeaderboardResponseDto extends BaseResponseDto<UserLeaderboardD
  *         slug:
  *           type: string
  *           description: 게시물 url slug 값
+ *         username:
+ *           type: string
+ *           nullable: true
+ *           description: 게시물 작성자 이름
  *         totalViews:
  *           type: integer
  *           description: 누적 조회수
@@ -110,6 +120,7 @@ interface LeaderboardPost {
   id: string;
   title: string;
   slug: string;
+  username: string | null;
   totalViews: number;
   totalLikes: number;
   viewDiff: number;

--- a/src/types/dto/responses/leaderboardResponse.type.ts
+++ b/src/types/dto/responses/leaderboardResponse.type.ts
@@ -16,7 +16,6 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
  *           nullable: true
  *         username:
  *           type: string
- *           nullable: true
  *           description: 사용자 이름
  *         totalViews:
  *           type: integer
@@ -40,7 +39,7 @@ import { BaseResponseDto } from '@/types/dto/responses/baseResponse.type';
 interface LeaderboardUser {
   id: string;
   email: string | null;
-  username: string | null;
+  username: string;
   totalViews: number;
   totalLikes: number;
   totalPosts: number;


### PR DESCRIPTION
## 🔥 변경 사항

리더보드 화면에서의 글/사용자 홈 바로가기를 위해 username 대응 개발을 하였습니다!
기존엔 Full URL을 응답에 내려주는 것으로 생각했었는데, [기준님과 대화](https://velogdashboard.slack.com/archives/C08062PN5PV/p1751014514664539) 나눈 결과, **URL은 일관성을 위해 FE에서 조합하는 방식**으로 진행될 예정입니다~!! (유저 리더보드의 경우엔 `https://velog.io/@username/posts` 형식)

- 리더보드 응답값에 `username` 필드 추가
  - **게시물 리더보드에선 `username` nullish함!!!**
  - `username 없는 사용자가 아주 드물음` && (`username 없음` = `사용자 업데이트 안됨` = `리더보드에 올라올 일 없음`)  => 그냥 Required라고 생각하셔도 될 것 같긴 합니다!
- 유저 리더보드 집계 포함 조건을 `email is not null` 에서 `username is not null`로 수정
  - 사용자 식별 목적 필드 `email` -> `username`
  - **따라서 원래 같이 내려주던 `email` 필드는 이제 nullish 합니다!!!** (아예 삭제도 고려)
- 관련 테스트 수정

## 🏷 관련 이슈
- X

## 📸 스크린샷 (UI 변경 시 필수)
X

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 및 게시글 리더보드 결과에 `username`(사용자명) 정보가 추가되었습니다.

* **버그 수정**
  * 리더보드에서 이메일이 없는 사용자 대신 사용자명이 없는 사용자가 제외되도록 변경되었습니다.

* **문서**
  * API 응답 문서에 `username` 필드가 추가 및 설명되었습니다.

* **테스트**
  * 모든 관련 테스트 데이터와 검증에 `username` 필드가 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->