### PR TITLE
[25.07.26 / TASK-212] Feature - Leaderboard에 캐싱 추가

### DIFF
--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -1,23 +1,34 @@
 import { Pool } from 'pg';
 import { DBError } from '@/exception';
 import { LeaderboardRepository } from '@/repositories/leaderboard.repository';
-import { LeaderboardService } from '@/services/leaderboard.service';
+import { LEADERBOARD_CACHE_TTL, LeaderboardService } from '@/services/leaderboard.service';
+import { ICache } from '@/modules/cache/cache.type';
 
 jest.mock('@/repositories/leaderboard.repository');
+jest.mock('@/configs/cache.config', () => ({
+  cache: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
 
 describe('LeaderboardService', () => {
   let service: LeaderboardService;
-  let repo: jest.Mocked<LeaderboardRepository>;
+  let mockRepo: jest.Mocked<LeaderboardRepository>;
   let mockPool: jest.Mocked<Pool>;
+  let mockCache: jest.Mocked<ICache>;
 
   beforeEach(() => {
     const mockPoolObj = {};
     mockPool = mockPoolObj as jest.Mocked<Pool>;
 
     const repoInstance = new LeaderboardRepository(mockPool);
-    repo = repoInstance as jest.Mocked<LeaderboardRepository>;
+    mockRepo = repoInstance as jest.Mocked<LeaderboardRepository>;
 
-    service = new LeaderboardService(repo);
+    const { cache } = jest.requireMock('@/configs/cache.config');
+    mockCache = cache as jest.Mocked<ICache>;
+
+    service = new LeaderboardService(mockRepo);
   });
 
   afterEach(() => {
@@ -25,83 +36,92 @@ describe('LeaderboardService', () => {
   });
 
   describe('getUserLeaderboard', () => {
-    it('응답 형식에 맞게 변환된 사용자 리더보드 데이터를 반환해야 한다', async () => {
-      const mockRawResult = [
+    const mockRawResult = [
+      {
+        id: '1',
+        email: 'test@test.com',
+        username: 'test',
+        total_views: '100',
+        total_likes: '50',
+        total_posts: '1',
+        view_diff: '20',
+        like_diff: '10',
+        post_diff: '1',
+      },
+      {
+        id: '2',
+        email: 'test2@test.com',
+        username: 'test2',
+        total_views: '200',
+        total_likes: '100',
+        total_posts: '2',
+        view_diff: '10',
+        like_diff: '5',
+        post_diff: '1',
+      },
+    ];
+
+    const mockResult = {
+      users: [
         {
           id: '1',
           email: 'test@test.com',
           username: 'test',
-          total_views: '100',
-          total_likes: '50',
-          total_posts: '1',
-          view_diff: '20',
-          like_diff: '10',
-          post_diff: '1',
+          totalViews: 100,
+          totalLikes: 50,
+          totalPosts: 1,
+          viewDiff: 20,
+          likeDiff: 10,
+          postDiff: 1,
         },
         {
           id: '2',
           email: 'test2@test.com',
           username: 'test2',
-          total_views: '200',
-          total_likes: '100',
-          total_posts: '2',
-          view_diff: '10',
-          like_diff: '5',
-          post_diff: '1',
+          totalViews: 200,
+          totalLikes: 100,
+          totalPosts: 2,
+          viewDiff: 10,
+          likeDiff: 5,
+          postDiff: 1,
         },
-      ];
+      ],
+    };
 
-      const mockResult = {
-        users: [
-          {
-            id: '1',
-            email: 'test@test.com',
-            username: 'test',
-            totalViews: 100,
-            totalLikes: 50,
-            totalPosts: 1,
-            viewDiff: 20,
-            likeDiff: 10,
-            postDiff: 1,
-          },
-          {
-            id: '2',
-            email: 'test2@test.com',
-            username: 'test2',
-            totalViews: 200,
-            totalLikes: 100,
-            totalPosts: 2,
-            viewDiff: 10,
-            likeDiff: 5,
-            postDiff: 1,
-          },
-        ],
-      };
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-      repo.getUserLeaderboard.mockResolvedValue(mockRawResult);
+    it('응답 형식에 맞게 변환된 사용자 리더보드 데이터를 반환해야 한다', async () => {
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getUserLeaderboard.mockResolvedValue(mockRawResult);
+
       const result = await service.getUserLeaderboard('viewCount', 30, 10);
 
       expect(result.users).toEqual(mockResult.users);
     });
 
     it('쿼리 파라미터가 올바르게 적용되어야 한다', async () => {
-      repo.getUserLeaderboard.mockResolvedValue([]);
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getUserLeaderboard.mockResolvedValue([]);
 
       await service.getUserLeaderboard('postCount', 30, 10);
 
-      expect(repo.getUserLeaderboard).toHaveBeenCalledWith('postCount', 30, 10);
+      expect(mockRepo.getUserLeaderboard).toHaveBeenCalledWith('postCount', 30, 10);
     });
 
     it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
-      repo.getUserLeaderboard.mockResolvedValue([]);
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getUserLeaderboard.mockResolvedValue([]);
 
       await service.getUserLeaderboard();
 
-      expect(repo.getUserLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
+      expect(mockRepo.getUserLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
     });
 
     it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
-      repo.getUserLeaderboard.mockResolvedValue([]);
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getUserLeaderboard.mockResolvedValue([]);
 
       const result = await service.getUserLeaderboard();
 
@@ -111,91 +131,124 @@ describe('LeaderboardService', () => {
     it('쿼리 오류 발생 시 예외를 그대로 전파한다', async () => {
       const errorMessage = '사용자 리더보드 조회 중 문제가 발생했습니다.';
       const dbError = new DBError(errorMessage);
-      repo.getUserLeaderboard.mockRejectedValue(dbError);
+
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getUserLeaderboard.mockRejectedValue(dbError);
 
       await expect(service.getUserLeaderboard()).rejects.toThrow(errorMessage);
-      expect(repo.getUserLeaderboard).toHaveBeenCalledTimes(1);
+      expect(mockRepo.getUserLeaderboard).toHaveBeenCalledTimes(1);
+    });
+
+    it('캐시 히트 시 Repository를 호출하지 않고 캐시된 데이터를 반환해야 한다', async () => {
+      mockCache.get.mockResolvedValue(mockResult);
+
+      const result = await service.getUserLeaderboard('viewCount', 30, 10);
+
+      expect(mockCache.get).toHaveBeenCalledWith('leaderboard:user:viewCount:30:10');
+      expect(mockRepo.getUserLeaderboard).not.toHaveBeenCalled();
+      expect(result).toEqual(mockResult);
+    });
+
+    it('캐시 미스 시 Repository를 호출하고 결과를 캐싱해야 한다', async () => {
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getUserLeaderboard.mockResolvedValue(mockRawResult);
+
+      const result = await service.getUserLeaderboard('postCount', 30, 10);
+
+      expect(mockRepo.getUserLeaderboard).toHaveBeenCalledWith('postCount', 30, 10);
+      expect(mockCache.set).toHaveBeenCalledWith('leaderboard:user:postCount:30:10', mockResult, LEADERBOARD_CACHE_TTL);
+      expect(result).toEqual(mockResult);
     });
   });
 
   describe('getPostLeaderboard', () => {
-    it('응답 형식에 맞게 변환된 게시물 리더보드 데이터를 반환해야 한다', async () => {
-      const mockRawResult = [
+    const mockRawResult = [
+      {
+        id: '1',
+        title: 'test',
+        slug: 'test-slug',
+        username: 'test',
+        total_views: '100',
+        total_likes: '50',
+        view_diff: '20',
+        like_diff: '10',
+        released_at: '2025-01-01',
+      },
+      {
+        id: '2',
+        title: 'test2',
+        slug: 'test2-slug',
+        username: 'test2',
+        total_views: '200',
+        total_likes: '100',
+        view_diff: '10',
+        like_diff: '5',
+        released_at: '2025-01-02',
+      },
+    ];
+
+    const mockResult = {
+      posts: [
         {
           id: '1',
           title: 'test',
           slug: 'test-slug',
           username: 'test',
-          total_views: '100',
-          total_likes: '50',
-          view_diff: '20',
-          like_diff: '10',
-          released_at: '2025-01-01',
+          totalViews: 100,
+          totalLikes: 50,
+          viewDiff: 20,
+          likeDiff: 10,
+          releasedAt: '2025-01-01',
         },
         {
           id: '2',
           title: 'test2',
           slug: 'test2-slug',
           username: 'test2',
-          total_views: '200',
-          total_likes: '100',
-          view_diff: '10',
-          like_diff: '5',
-          released_at: '2025-01-02',
+          totalViews: 200,
+          totalLikes: 100,
+          viewDiff: 10,
+          likeDiff: 5,
+          releasedAt: '2025-01-02',
         },
-      ];
+      ],
+    };
 
-      const mockResult = {
-        posts: [
-          {
-            id: '1',
-            title: 'test',
-            slug: 'test-slug',
-            username: 'test',
-            totalViews: 100,
-            totalLikes: 50,
-            viewDiff: 20,
-            likeDiff: 10,
-            releasedAt: '2025-01-01',
-          },
-          {
-            id: '2',
-            title: 'test2',
-            slug: 'test2-slug',
-            username: 'test2',
-            totalViews: 200,
-            totalLikes: 100,
-            viewDiff: 10,
-            likeDiff: 5,
-            releasedAt: '2025-01-02',
-          },
-        ],
-      };
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-      repo.getPostLeaderboard.mockResolvedValue(mockRawResult);
+    it('응답 형식에 맞게 변환된 게시물 리더보드 데이터를 반환해야 한다', async () => {
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getPostLeaderboard.mockResolvedValue(mockRawResult);
+
       const result = await service.getPostLeaderboard('viewCount', 30, 10);
 
       expect(result.posts).toEqual(mockResult.posts);
     });
 
     it('쿼리 파라미터가 올바르게 적용되어야 한다', async () => {
-      repo.getPostLeaderboard.mockResolvedValue([]);
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getPostLeaderboard.mockResolvedValue([]);
 
       await service.getPostLeaderboard('likeCount', 30, 10);
 
-      expect(repo.getPostLeaderboard).toHaveBeenCalledWith('likeCount', 30, 10);
+      expect(mockRepo.getPostLeaderboard).toHaveBeenCalledWith('likeCount', 30, 10);
     });
 
     it('쿼리 파라미터가 입력되지 않은 경우 기본값으로 처리되어야 한다', async () => {
-      repo.getPostLeaderboard.mockResolvedValue([]);
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getPostLeaderboard.mockResolvedValue([]);
 
       await service.getPostLeaderboard();
 
-      expect(repo.getPostLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
+      expect(mockRepo.getPostLeaderboard).toHaveBeenCalledWith('viewCount', 30, 10);
     });
 
     it('데이터가 없는 경우 빈 배열을 반환해야 한다', async () => {
-      repo.getPostLeaderboard.mockResolvedValue([]);
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getPostLeaderboard.mockResolvedValue([]);
+
       const result = await service.getPostLeaderboard();
 
       expect(result).toEqual({ posts: [] });
@@ -204,10 +257,33 @@ describe('LeaderboardService', () => {
     it('쿼리 오류 발생 시 예외를 그대로 전파한다', async () => {
       const errorMessage = '게시물 리더보드 조회 중 문제가 발생했습니다.';
       const dbError = new DBError(errorMessage);
-      repo.getPostLeaderboard.mockRejectedValue(dbError);
+
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getPostLeaderboard.mockRejectedValue(dbError);
 
       await expect(service.getPostLeaderboard()).rejects.toThrow(errorMessage);
-      expect(repo.getPostLeaderboard).toHaveBeenCalledTimes(1);
+      expect(mockRepo.getPostLeaderboard).toHaveBeenCalledTimes(1);
+    });
+
+    it('캐시 히트 시 Repository를 호출하지 않고 캐시된 데이터를 반환해야 한다', async () => {
+      mockCache.get.mockResolvedValue(mockResult);
+
+      const result = await service.getPostLeaderboard('viewCount', 30, 10);
+
+      expect(mockCache.get).toHaveBeenCalledWith('leaderboard:post:viewCount:30:10');
+      expect(mockRepo.getPostLeaderboard).not.toHaveBeenCalled();
+      expect(result).toEqual(mockResult);
+    });
+
+    it('캐시 미스 시 Repository를 호출하고 결과를 캐싱해야 한다', async () => {
+      mockCache.get.mockResolvedValue(null);
+      mockRepo.getPostLeaderboard.mockResolvedValue(mockRawResult);
+
+      const result = await service.getPostLeaderboard('likeCount', 30, 10);
+
+      expect(mockRepo.getPostLeaderboard).toHaveBeenCalledWith('likeCount', 30, 10);
+      expect(mockCache.set).toHaveBeenCalledWith('leaderboard:post:likeCount:30:10', mockResult, LEADERBOARD_CACHE_TTL);
+      expect(result).toEqual(mockResult);
     });
   });
 });

--- a/src/services/__test__/leaderboard.service.test.ts
+++ b/src/services/__test__/leaderboard.service.test.ts
@@ -88,10 +88,6 @@ describe('LeaderboardService', () => {
       ],
     };
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('응답 형식에 맞게 변환된 사용자 리더보드 데이터를 반환해야 한다', async () => {
       mockCache.get.mockResolvedValue(null);
       mockRepo.getUserLeaderboard.mockResolvedValue(mockRawResult);
@@ -213,10 +209,6 @@ describe('LeaderboardService', () => {
         },
       ],
     };
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
 
     it('응답 형식에 맞게 변환된 게시물 리더보드 데이터를 반환해야 한다', async () => {
       mockCache.get.mockResolvedValue(null);


### PR DESCRIPTION
## 🔥 변경 사항

- Leaderboard 서비스 계층에 redis 캐시 레이어를 추가하였습니다.
- 관련되어 유닛 테스트 케이스를 추가하였습니다.

## 🏷 관련 이슈
- X

## 📸 스크린샷 (UI 변경 시 필수)
X

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 유저 및 게시글 리더보드 조회 시 캐시가 적용되어, 동일한 조건의 요청에 대해 더 빠른 응답이 제공됩니다.

* **테스트**
  * 리더보드 서비스의 캐시 동작을 검증하는 테스트가 추가 및 개선되었습니다.  
  * 캐시 적중 및 미적중 시나리오가 모두 테스트에 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->