### PR TITLE
[25.08.25 / TASK-247] Fix - Leaderboard 쿼리 결과값 버그 수정

### DIFF
--- a/src/repositories/__test__/leaderboard.repo.test.ts
+++ b/src/repositories/__test__/leaderboard.repo.test.ts
@@ -79,8 +79,17 @@ describe('LeaderboardRepository', () => {
       await repo.getUserLeaderboard('viewCount', mockDateRange, 10);
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('WHERE date >='), // pastDateKST를 사용하는 부분 확인
+        expect.stringContaining('WHERE date ='), // pastDateKST를 사용하는 부분 확인
         [expect.any(Number)], // limit
+      );
+    });
+
+    it('데이터 수집이 비정상적인 유저는 리더보드에 포함되지 않아야 한다', async () => {
+      await repo.getUserLeaderboard('viewCount', 30, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('HAVING SUM(COALESCE(ts.today_view, 0)) != SUM(COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, 0))'),
+        expect.anything(),
       );
     });
 
@@ -156,8 +165,17 @@ describe('LeaderboardRepository', () => {
       await repo.getPostLeaderboard('viewCount', mockDateRange, 10);
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('WHERE date >='), // pastDateKST를 사용하는 부분 확인
+        expect.stringContaining('WHERE date ='), // pastDateKST를 사용하는 부분 확인
         [expect.any(Number)], // limit
+      );
+    });
+
+    it('데이터 수집이 비정상적인 게시물은 리더보드에 포함되지 않아야 한다', async () => {
+      await repo.getPostLeaderboard('viewCount', 30, 10);
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('COALESCE(ts.today_view, 0) != COALESCE(ts.today_view, 0) - COALESCE(ss.start_view, 0)'),
+        expect.anything()
       );
     });
 

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -10,7 +10,7 @@ export class LeaderboardRepository {
   async getUserLeaderboard(sort: UserLeaderboardSortType, dateRange: number, limit: number) {
     try {
       const pastDateKST = getKSTDateStringWithOffset(-dateRange * 24 * 60);
-      const cteQuery = this.buildLeaderboardCteQuery(dateRange);
+      const cteQuery = this.buildLeaderboardCteQuery(dateRange, pastDateKST);
 
       const query = `
         ${cteQuery}
@@ -46,7 +46,7 @@ export class LeaderboardRepository {
   async getPostLeaderboard(sort: PostLeaderboardSortType, dateRange: number, limit: number) {
     try {
       const pastDateKST = getKSTDateStringWithOffset(-dateRange * 24 * 60);
-      const cteQuery = this.buildLeaderboardCteQuery(dateRange);
+      const cteQuery = this.buildLeaderboardCteQuery(dateRange, pastDateKST);
 
       const query = `
         ${cteQuery}
@@ -83,10 +83,11 @@ export class LeaderboardRepository {
   }
 
   // 오늘 날짜와 기준 날짜의 통계를 가져오는 CTE(임시 결과 집합) 쿼리 빌드
-  private buildLeaderboardCteQuery(dateRange: number) {
+  private buildLeaderboardCteQuery(dateRange: number, pastDateKST?: string) {
     const nowDateKST = getCurrentKSTDateString();
-    // 과거 날짜 계산 (dateRange일 전)
-    const pastDateKST = getKSTDateStringWithOffset(-dateRange * 24 * 60);
+    if (!pastDateKST) {
+      pastDateKST = getKSTDateStringWithOffset(-dateRange * 24 * 60);
+    }
 
     return `
       WITH 


### PR DESCRIPTION
## 🔥 변경 사항

(통합 테스트 업데이트중)

- 문제: total_stats API에서 보는 `view_diff`와 leaderboard API에서 보는 `view_diff` 값의 불일치 (리더보드가 더 적게 표시)
- 원인: 리더보드 데이터 집계시, 해당 기간 내 발행된 새 글의 첫 통계 데이터가 무시됨
- 해결
  - 기존에 과거 통계 데이터와 오늘 통계 데이터 수집시, 유연한 데이터 선정을 위해 넣은 부등호를 삭제함
  - 따라서 n일 전 당일의 데이터를 사용하고, 없는 경우 0으로 대체

## 🏷 관련 이슈
- 없음

## 📸 스크린샷 (UI 변경 시 필수)
없음

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)
