### PR TITLE
[25.10.01 / TASK-248] Refactor - 에러 로그 개선 및 액세스 로그 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { options } from '@/configs/swagger.config';
 import { getSentryStatus } from '@/configs/sentry.config';
 import { getCacheStatus } from '@/configs/cache.config';
 import { errorHandlingMiddleware } from '@/middlewares/errorHandling.middleware';
+import { accessLogMiddleware } from '@/middlewares/accessLog.middleware';
 
 dotenv.config();
 
@@ -24,6 +25,7 @@ app.set('trust proxy', process.env.NODE_ENV === 'production');
 
 const swaggerSpec = swaggerJSDoc(options);
 
+app.use(accessLogMiddleware);
 app.use(cookieParser());
 app.use(express.json({ limit: '10mb' })); // 파일 업로드 대비
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));

--- a/src/configs/logger.config.ts
+++ b/src/configs/logger.config.ts
@@ -13,6 +13,16 @@ if (!fs.existsSync(errorLogDir)) {
 }
 
 const jsonFormat = winston.format.printf((info) => {
+  // info.message가 객체인 경우
+  if (typeof info.message === 'object' && info.message !== null) {
+    return JSON.stringify({
+      timestamp: info.timestamp,
+      level: info.level.toUpperCase(),
+      logger: info.logger || 'default',
+      ...info.message, // 로그 데이터 평탄화
+    });
+  }
+
   return JSON.stringify({
     timestamp: info.timestamp,
     level: info.level.toUpperCase(),

--- a/src/middlewares/accessLog.middleware.ts
+++ b/src/middlewares/accessLog.middleware.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import { recordRequestStart, logAccess } from '@/utils/logging.util';
+
+/**
+ * 액세스 로그 미들웨어
+ * 모든 요청의 시작과 끝을 기록합니다.
+ */
+export const accessLogMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  // 요청 시작 시점 기록
+  recordRequestStart(req);
+
+  // 응답 완료 시 액세스 로그 기록
+  res.on('finish', () => {
+    if (res.statusCode < 400) {
+      // 400 이상은 에러 로그로 처리
+      logAccess(req, res);
+    }
+  });
+
+  next();
+};

--- a/src/middlewares/validation.middleware.ts
+++ b/src/middlewares/validation.middleware.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import logger from '@/configs/logger.config';
+import { BadRequestError } from '@/exception';
 
 type RequestKey = 'body' | 'user' | 'query';
 
@@ -16,16 +17,7 @@ export const validateRequestDto = <T extends object>(
       const errors = await validate(value);
 
       if (errors.length > 0) {
-        logger.error(`API 입력 검증 실패, errors: ${errors}`);
-        res.status(400).json({
-          success: false,
-          message: '검증에 실패하였습니다. 입력값을 다시 확인해주세요.',
-          errors: errors.map((error) => ({
-            property: error.property,
-            constraints: error.constraints,
-          })),
-        });
-        return;
+        throw new BadRequestError(`API 입력 검증 실패, errors: ${errors}`);
       }
 
       req[key] = value as T;

--- a/src/middlewares/validation.middleware.ts
+++ b/src/middlewares/validation.middleware.ts
@@ -1,7 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import logger from '@/configs/logger.config';
 import { BadRequestError } from '@/exception';
 
 type RequestKey = 'body' | 'user' | 'query';
@@ -23,7 +22,6 @@ export const validateRequestDto = <T extends object>(
       req[key] = value as T;
       next();
     } catch (error) {
-      logger.error(`${key} Dto 검증 중 오류 발생 : `, error);
       next(error);
     }
   };

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -8,6 +8,8 @@ declare global {
         accessToken: string;
         refreshToken: string;
       };
+      requestId: string;
+      startTime: number;
     }
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,5 +42,8 @@ export { TotalStatsResponseDto } from '@/types/dto/responses/totalStatsResponse.
 export type { SentryIssueStatus } from '@/types/models/Sentry.type';
 export type { SentryProject, SentryIssue, SentryWebhookData } from '@/types/models/Sentry.type';
 
+// Logging 관련
+export type { LogContext, ErrorLogData, AccessLogData } from '@/types/logging';
+
 // Common
 export { EmptyResponseDto } from '@/types/dto/responses/emptyReponse.type';

--- a/src/types/logging.ts
+++ b/src/types/logging.ts
@@ -1,0 +1,33 @@
+/**
+ * 기본 로그 컨텍스트 정보
+ */
+export interface LogContext {
+  requestId: string;
+  userId?: string;
+  method: string;
+  url: string;
+  userAgent?: string;
+  ip?: string;
+}
+
+/**
+ * 에러 로그 데이터
+ */
+export interface ErrorLogData extends LogContext {
+  logger: string;
+  message: string;
+  statusCode: number;
+  errorCode?: string;
+  stack?: string;
+  responseTime?: number;
+}
+
+/**
+ * 액세스 로그 데이터
+ */
+export interface AccessLogData extends LogContext {
+  logger: string;
+  statusCode: number;
+  responseTime: number;
+  responseSize?: number;
+}

--- a/src/types/logging.ts
+++ b/src/types/logging.ts
@@ -3,7 +3,7 @@
  */
 export interface LogContext {
   requestId: string;
-  userId?: string;
+  userId?: number;
   method: string;
   url: string;
   userAgent?: string;

--- a/src/utils/__test__/logging.util.test.ts
+++ b/src/utils/__test__/logging.util.test.ts
@@ -1,0 +1,162 @@
+import { Request, Response } from 'express';
+import { Socket } from 'net';
+import { 
+  createLogContext, 
+  logError, 
+  logAccess, 
+  getClientIp,
+  getLogLevel,
+} from '@/utils/logging.util';
+import { CustomError } from '@/exception';
+import { User } from '@/types';
+import logger from '@/configs/logger.config';
+
+// logger 모킹
+jest.mock('@/configs/logger.config', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+}));
+
+describe('Logging Utilities', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  beforeEach(() => {
+    mockRequest = {
+      headers: {'x-forwarded-for': '127.0.0.1'},
+      method: 'GET',
+      originalUrl: '/api/test', 
+      /* eslint-disable @typescript-eslint/consistent-type-assertions */
+      user: { id: 123, velog_uuid: 'user123' } as User,
+      requestId: 'test-request-id',
+      startTime: Date.now() - 100,
+    };
+    
+    mockResponse = {
+      statusCode: 200,
+      get: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getClientIp', () => {
+    it('x-forwarded-for 헤더에서 IP를 추출해야 한다', () => {
+      mockRequest.headers = { 'x-forwarded-for': '192.168.1.1, 10.0.0.1' };
+      expect(getClientIp(mockRequest as Request)).toBe('192.168.1.1');
+    });
+
+    it('x-real-ip 헤더에서 IP를 추출해야 한다', () => {
+      mockRequest.headers = { 'x-real-ip': '203.0.113.1' };
+      expect(getClientIp(mockRequest as Request)).toBe('203.0.113.1');
+    });
+
+    it('헤더가 없으면 unknown을 반환해야 한다', () => {
+      mockRequest.headers = {};
+      /* eslint-disable @typescript-eslint/consistent-type-assertions */
+      mockRequest.socket = { remoteAddress: undefined } as Socket;
+      expect(getClientIp(mockRequest as Request)).toBe('unknown');
+    });
+  });
+
+  describe('getLogLevel', () => {
+    it('200은 info 레벨을 반환해야 한다', () => {
+      expect(getLogLevel(200)).toBe('info');
+    });
+
+    it('404는 warn 레벨을 반환해야 한다', () => {
+      expect(getLogLevel(404)).toBe('warn');
+    });
+
+    it('500은 error 레벨을 반환해야 한다', () => {
+      expect(getLogLevel(500)).toBe('error');
+    });
+  });
+
+  describe('createLogContext', () => {
+    it('요청에서 올바른 로그 컨텍스트를 생성해야 한다', () => {
+      const context = createLogContext(mockRequest as Request);
+      
+      expect(context.requestId).toBe('test-request-id');
+      expect(context.userId).toBe(123);
+      expect(context.method).toBe('GET');
+      expect(context.url).toBe('/api/test');
+      expect(context.userAgent).toBeUndefined();
+      expect(context.ip).toBe('127.0.0.1');
+    });
+  });
+
+  describe('logError', () => {
+    it('일반 에러를 올바르게 로깅해야 한다', () => {
+      const error = new Error('Test error');
+      mockResponse.statusCode = 500; // error 레벨을 위해 500으로 설정
+      
+      logError(mockRequest as Request, mockResponse as Response, error);
+      
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            logger: 'error',
+            message: 'Test error',
+            statusCode: 500,
+            requestId: 'test-request-id',
+            userId: 123,
+            method: 'GET',
+            url: '/api/test',
+            ip: '127.0.0.1',
+          })
+        })
+      );
+    });
+
+    it('CustomError의 경우 에러 코드를 포함해야 한다', () => {
+      const customError = new CustomError('Custom error', 'CUSTOM_ERROR', 400);
+      mockResponse.statusCode = 400;
+      
+      logError(mockRequest as Request, mockResponse as Response, customError);
+      
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            errorCode: 'CUSTOM_ERROR',
+          })
+        })
+      );
+    });
+
+    it('500이거나 예상하지 못한 에러는 스택 트레이스를 포함해야 한다', () => {
+      const error = new Error('Test error');
+      mockResponse.statusCode = 500;
+      
+      logError(mockRequest as Request, mockResponse as Response, error);
+      
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            stack: expect.any(String),
+          })
+        })
+      );
+    });
+  });
+
+  describe('logAccess', () => {
+    it('액세스 로그를 올바르게 생성해야 한다', () => {
+      (mockResponse.get as jest.Mock).mockReturnValue('1024');
+      
+      logAccess(mockRequest as Request, mockResponse as Response);
+      
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          logger: 'access',
+          statusCode: 200,
+          responseTime: expect.any(Number),
+          responseSize: 1024,
+        })
+      );
+    });
+  });
+});

--- a/src/utils/logging.util.ts
+++ b/src/utils/logging.util.ts
@@ -22,7 +22,7 @@ export const getClientIp = (req: Request): string => {
 export const createLogContext = (req: Request): LogContext => {
   return {
     requestId: req.requestId || randomUUID(),
-    userId: req.user?.velog_uuid,
+    userId: req.user?.id,
     method: req.method,
     url: req.originalUrl || req.url,
     userAgent: req.headers['user-agent'],

--- a/src/utils/logging.util.ts
+++ b/src/utils/logging.util.ts
@@ -1,0 +1,128 @@
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import logger from '@/configs/logger.config';
+import { LogContext, ErrorLogData, AccessLogData } from '@/types/logging';
+import { CustomError } from '@/exception';
+
+/**
+ * 클라이언트 IP 주소 추출
+ */
+export const getClientIp = (req: Request): string => {
+  return (
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0] ||
+    (req.headers['x-real-ip'] as string) ||
+    req.socket.remoteAddress ||
+    'unknown'
+  );
+};
+
+/**
+ * 요청에서 기본 로그 컨텍스트 생성
+ */
+export const createLogContext = (req: Request): LogContext => {
+  return {
+    requestId: req.requestId || randomUUID(),
+    userId: req.user?.velog_uuid,
+    method: req.method,
+    url: req.originalUrl || req.url,
+    userAgent: req.headers['user-agent'],
+    ip: getClientIp(req),
+  };
+};
+
+/**
+ * 로그 레벨과 로거 이름 결정
+ */
+export const getLogLevel = (statusCode: number): 'info' | 'warn' | 'error' => {
+  if (statusCode < 400) return 'info';
+  if (statusCode === 404) return 'warn';
+  return 'error';
+};
+
+/**
+ * 에러 로그 생성 및 출력
+ *
+ * @param req Express Request 객체
+ * @param res Express Response 객체
+ * @param error Error 객체
+ * @param customMessage 커스텀 에러 메시지 (선택)
+ * @param additionalData 추가 로그 데이터 (선택)
+ */
+export const logError = (
+  req: Request,
+  res: Response,
+  error: Error,
+  customMessage?: string,
+  additionalData?: Record<string, unknown>,
+): void => {
+  const statusCode = res.statusCode || 500;
+  const level = getLogLevel(statusCode);
+
+  const context = createLogContext(req);
+  const responseTime = req.startTime ? Date.now() - req.startTime : undefined;
+
+  // 스택 트레이스 포함 여부 결정
+  const includeStack = error instanceof CustomError && error.statusCode < 500 ? false : true;
+
+  // 기본 에러 로그 데이터 생성 (winston 기본 필드 제외)
+  const errorLogData: ErrorLogData = {
+    logger: 'error',
+    requestId: context.requestId,
+    userId: context.userId,
+    method: context.method,
+    url: context.url,
+    userAgent: context.userAgent,
+    ip: context.ip,
+    message: customMessage || error.message,
+    statusCode,
+    errorCode: error instanceof CustomError ? error.code : undefined,
+    ...(includeStack && { stack: error.stack }),
+    responseTime,
+    ...additionalData,
+  };
+
+  logger[level]({ message: errorLogData });
+};
+
+/**
+ * 액세스 로그 생성 및 출력
+ *
+ * @param req Express Request 객체
+ * @param res Express Response 객체
+ * @param additionalData 추가 로그 데이터 (선택)
+ */
+export const logAccess = (req: Request, res: Response, additionalData?: Record<string, unknown>): void => {
+  const statusCode = res.statusCode;
+  const level = getLogLevel(statusCode);
+
+  const context = createLogContext(req);
+  const responseTime = req.startTime ? Date.now() - req.startTime : 0;
+
+  // 응답 크기 추정 (정확하지 않을 수 있음)
+  const contentLength = res.get('content-length');
+  const responseSize = contentLength ? parseInt(contentLength, 10) : undefined;
+
+  const accessLogData: AccessLogData = {
+    logger: 'access',
+    requestId: context.requestId,
+    userId: context.userId,
+    method: context.method,
+    url: context.url,
+    userAgent: context.userAgent,
+    ip: context.ip,
+    statusCode,
+    responseTime,
+    responseSize,
+    ...additionalData,
+  };
+
+  logger[level](accessLogData);
+};
+
+/**
+ * 요청 시작 시점 기록을 위한 미들웨어 헬퍼
+ */
+export const recordRequestStart = (req: Request): void => {
+  req.requestId = req.requestId || randomUUID();
+  req.startTime = Date.now();
+};


### PR DESCRIPTION
## 🔥 변경 사항

기존에 메세지 위주로만 남기던 에러 로그들을 개선하고, 액세스 로그를 추가하였습니다.

- 앱에서 발생하는 400 이상의 에러는 에러핸들링 미들웨어를 통해 context들과 함께 로깅됩니다.
- 성공적인(400 미만) 요청들은 액세스로그 미들웨어를 통해 context들과 함께 로깅됩니다.
- 기존의 로그들은 삭제하지 않고 추적할 수 있도록 남겨두었습니다. (스크린샷 참고)
- logger 분기: 기존에 각 계층에서 찍던 에러는 default로(기존 유지), 에러 핸들링 미들웨어를 거쳐가는 로그는 error, 액세스 로그는 access로 찍도록 하였습니다.

## 🏷 관련 이슈
- X

## 📸 스크린샷 (UI 변경 시 필수)

### 잘못된 로그인

<img width="1494" height="308" alt="image" src="https://github.com/user-attachments/assets/f476733e-8efd-43ba-bcd9-de00469d9568" />

1. 벨로그 유틸에서 찍는 로그 (default)
2. login 컨트롤러에서 찍는 로그 (default)
3. 에러 핸들러에서 찍는 로그 (error)

### repo에서의 DB 에러시

<img width="1490" height="538" alt="image" src="https://github.com/user-attachments/assets/2e3a2325-95a1-4b12-9123-ad5f80eedaf2" />

1. repo (default)
2. service (default)
3. controller (default)
4. 에러 핸들러 (error)

### 쿼리 파라미터 타입 에러

<img width="1504" height="204" alt="image" src="https://github.com/user-attachments/assets/e1a6bec6-db99-4a0b-8d84-2efc31a0aefb" />

### not found (에러 중 유일하게 WARN)

<img width="1502" height="148" alt="image" src="https://github.com/user-attachments/assets/673407c5-579b-448b-90fd-44fb271a7456" />

### 성공적인 액세스 로그

<img width="1500" height="648" alt="image" src="https://github.com/user-attachments/assets/f5829a75-cc56-4a5e-bea0-16251a451fcd" />


## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)
