### PR TITLE
[25.10.04 / TASK-250] Feature - 주간 뉴스레터 수신거부 API 추가

### DIFF
--- a/src/controllers/__test__/user.controller.test.ts
+++ b/src/controllers/__test__/user.controller.test.ts
@@ -405,4 +405,44 @@ describe('UserController', () => {
       expect(mockResponse.redirect).not.toHaveBeenCalled();
     });
   });
+
+  describe('unsubscribeNewsletter', () => {
+    beforeEach(() => {
+      mockRequest.query = {};
+      mockResponse.redirect = jest.fn().mockReturnThis();
+    });
+
+    it('이메일이 없으면 BadRequestError를 던져야 한다', async () => {
+      mockRequest.query = {};
+
+      await userController.unsubscribeNewsletter(
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      expect(nextFunction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '이메일이 필요합니다.',
+        })
+      );
+      expect(mockResponse.redirect).not.toHaveBeenCalled();
+    });
+
+    it('구독 해제 완료시 메인 페이지로 리다이렉트해야 한다', async () => {
+      const email = 'test@example.com';
+      mockRequest.query = { email };
+      mockUserService.unsubscribeNewsletter.mockResolvedValue(undefined);
+
+      await userController.unsubscribeNewsletter(
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      expect(mockUserService.unsubscribeNewsletter).toHaveBeenCalledWith(email);
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/main');
+      expect(nextFunction).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -3,9 +3,8 @@ import logger from '@/configs/logger.config';
 import { EmptyResponseDto, LoginResponseDto } from '@/types';
 import { QRLoginTokenResponseDto } from '@/types/dto/responses/qrResponse.type';
 import { UserService } from '@/services/user.service';
-import { QRTokenExpiredError, QRTokenInvalidError } from '@/exception/token.exception';
 import { fetchVelogApi } from '@/modules/velog/velog.api';
-import { BadRequestError } from '@/exception';
+import { QRTokenExpiredError, QRTokenInvalidError, BadRequestError } from '@/exception';
 
 type Token10 = string & { __lengthBrand: 10 };
 
@@ -172,7 +171,7 @@ export class UserController {
   };
 
   unsubscribeNewsletter: RequestHandler = async (req: Request, res: Response<EmptyResponseDto>, next: NextFunction) => {
-    try { 
+    try {
       const email = req.query.email as string;
       if (!email) {
         throw new BadRequestError('이메일이 필요합니다.');

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -5,6 +5,7 @@ import { QRLoginTokenResponseDto } from '@/types/dto/responses/qrResponse.type';
 import { UserService } from '@/services/user.service';
 import { QRTokenExpiredError, QRTokenInvalidError } from '@/exception/token.exception';
 import { fetchVelogApi } from '@/modules/velog/velog.api';
+import { BadRequestError } from '@/exception';
 
 type Token10 = string & { __lengthBrand: 10 };
 
@@ -166,6 +167,21 @@ export class UserController {
       res.redirect('/main');
     } catch (error) {
       logger.error(`QR 토큰 로그인 처리 실패: [userId: ${req.user?.id || 'anonymous'}]`, error);
+      next(error);
+    }
+  };
+
+  unsubscribeNewsletter: RequestHandler = async (req: Request, res: Response<EmptyResponseDto>, next: NextFunction) => {
+    try { 
+      const email = req.query.email as string;
+      if (!email) {
+        throw new BadRequestError('이메일이 필요합니다.');
+      }
+
+      await this.userService.unsubscribeNewsletter(email);
+      res.redirect('/main');
+    } catch (error) {
+      logger.error(`뉴스레터 구독 해제 실패: [email: ${req.query.email}]`, error);
       next(error);
     }
   };

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -7,7 +7,7 @@ import { DBError } from '@/exception';
 export class UserRepository {
   constructor(private readonly pool: Pool) {}
 
-  async findByUserId(id: number): Promise<User> {
+  async findByUserId(id: number): Promise<User | null> {
     try {
       const user = await this.pool.query('SELECT * FROM "users_user" WHERE id = $1', [id]);
       return user.rows[0] || null;
@@ -17,12 +17,22 @@ export class UserRepository {
     }
   }
 
-  async findByUserVelogUUID(uuid: string): Promise<User> {
+  async findByUserVelogUUID(uuid: string): Promise<User | null> {
     try {
       const user = await this.pool.query('SELECT * FROM "users_user" WHERE velog_uuid = $1', [uuid]);
       return user.rows[0] || null;
     } catch (error) {
       logger.error('Velog UUID로 유저를 조회 중 오류 : ', error);
+      throw new DBError('유저 조회 중 문제가 발생했습니다.');
+    }
+  }
+
+  async findByUserEmail(email: string): Promise<User | null> {
+    try {
+      const user = await this.pool.query('SELECT * FROM "users_user" WHERE email = $1', [email]);
+      return user.rows[0] || null;
+    } catch (error) {
+      logger.error('Email로 유저를 조회 중 오류 : ', error);
       throw new DBError('유저 조회 중 문제가 발생했습니다.');
     }
   }
@@ -150,6 +160,16 @@ export class UserRepository {
     } catch (error) {
       logger.error('QRLoginToken Repo mark as used Error : ', error);
       throw new DBError('QR 코드 사용 처리 중 문제가 발생했습니다.');
+    }
+  }
+
+  async unsubscribeNewsletter(id: number): Promise<void> {
+    try {
+      const query = `UPDATE "users_user" SET newsletter_subscribed = false WHERE id = $1`;
+      await this.pool.query(query, [id]);
+    } catch (error) {
+      logger.error('User Repo unsubscribeNewsletter Error : ', error);
+      throw new DBError('뉴스레터 구독 해제 중 문제가 발생했습니다.');
     }
   }
 }

--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -151,4 +151,25 @@ router.post('/qr-login', authMiddleware.verify, userController.createToken);
  */
 router.get('/qr-login', userController.getToken);
 
+/**
+ * @swagger
+ * /newsletter-unsubscribe:
+ *   get:
+ *     tags: 
+ *       - User
+ *     summary: 뉴스레터 구독 해제 (메일에서 바로 접근)
+ *     parameters:
+ *       - in: query
+ *         name: email
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 구독을 해제할 이메일
+ *     responses:
+ *       302:
+ *         description: 뉴스레터 구독 해제 성공 후 메인 페이지로 리디렉션
+ */
+router.get('/newsletter-unsubscribe', userController.unsubscribeNewsletter);
+
+
 export default router;

--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -155,7 +155,7 @@ router.get('/qr-login', userController.getToken);
  * @swagger
  * /newsletter-unsubscribe:
  *   get:
- *     tags: 
+ *     tags:
  *       - User
  *     summary: 뉴스레터 구독 해제 (메일에서 바로 접근)
  *     parameters:
@@ -170,6 +170,5 @@ router.get('/qr-login', userController.getToken);
  *         description: 뉴스레터 구독 해제 성공 후 메인 페이지로 리디렉션
  */
 router.get('/newsletter-unsubscribe', userController.unsubscribeNewsletter);
-
 
 export default router;

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -170,4 +170,19 @@ export class UserService {
     );
     return { decryptedAccessToken, decryptedRefreshToken };
   }
+
+  async unsubscribeNewsletter(email: string) {
+    try {
+      const user = await this.userRepo.findByUserEmail(email);
+      if (!user) {
+        logger.error(`유저를 찾을 수 없습니다. [email: ${email}]`);
+        return; // 일반적인 실패시 리디렉션
+      }
+
+      await this.userRepo.unsubscribeNewsletter(user.id);
+    } catch (error) {
+      logger.error('User Service unsubscribeNewsletter Error : ', error);
+      throw error;
+    }
+  }
 }

--- a/src/types/models/User.type.ts
+++ b/src/types/models/User.type.ts
@@ -11,6 +11,8 @@ export interface User {
   // 250607 추가
   username: string | null;
   thumbnail: string | null;
+  // 251004 추가
+  newsletter_subscribed: boolean;
 }
 
 

--- a/src/utils/fixtures.ts
+++ b/src/utils/fixtures.ts
@@ -37,6 +37,7 @@ export const mockUser: User = {
   is_active: true,
   created_at: new Date('2024-01-01T00:00:00Z'),
   updated_at: new Date('2024-01-01T00:00:00Z'),
+  newsletter_subscribed: true,
 };
 
 /**


### PR DESCRIPTION
## 🔥 변경 사항

주간 뉴스레터 수신 거부 API(`/user/newsletter-unsubscribe`)를 추가하였습니다.
- 뉴스레터 템플릿에서 "수신 거부" 버튼을 통해 API에 직접 접근 (GET)
- 구독 해제후 `/main`으로 리디렉트

## 🏷 관련 이슈
- https://github.com/Check-Data-Out/velog-dashboard-v2-back-office/pull/46 과 유기적

## 📸 스크린샷 (UI 변경 시 필수)
X

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)
