### PR TITLE
[26.04.04 / TASK-268] Chore - 프로덕션용 환경변수 파일 `.env.prod` 추가

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,37 +1,37 @@
 PORT=8080
-ALLOWED_ORIGINS=http://localhost,http://localhost:3000,http://158.180.72.158,http://velog-dashboard.kro.kr,https://velog-dashboard.kro.kr,http://velog.io,https://velog.io
-NODE_ENV="development"
+ALLOWED_ORIGINS=http://localhost,http://localhost:3000
+NODE_ENV=development
 
 # 토큰 단방향 암호화 전용 핵심 키
-AES_KEY_0=13ccb93c17a8d6e49ba3c5d91e3a6f45
-AES_KEY_1=76e2a34bf23cd45876bc91e6a87d3f22
-AES_KEY_2=93a4d7e6b34ac8f1092fd5e87a93bc56
-AES_KEY_3=b87f6c34d92fa17e3b2a67e58c93fa56
-AES_KEY_4=27e3b8f67c4a12d8f93a6b17d4e58fa9
-AES_KEY_5=6b83c9e21a7d48fa3f9b27e45c8a6f12
-AES_KEY_6=81f92ab73c4e59d8a67f83b21d6e4c53
-AES_KEY_7=d87b61e9f34a2c85f19a7e53c6d8f21a
-AES_KEY_8=7c58f92ae1d3b67a4c29f8b36e17d4f9
-AES_KEY_9=a93b4f7e2c6d81a7f5c3b2e89d47f612
+AES_KEY_0=
+AES_KEY_1=
+AES_KEY_2=
+AES_KEY_3=
+AES_KEY_4=
+AES_KEY_5=
+AES_KEY_6=
+AES_KEY_7=
+AES_KEY_8=
+AES_KEY_9=
 
 # Database
-DATABASE_NAME=vd2
-POSTGRES_USER=vd2
-POSTGRES_PASSWORD=vd2
+DATABASE_NAME=postgres
+POSTGRES_USER=
+POSTGRES_PASSWORD=
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 
 # Cache (redis)
 REDIS_HOST=localhost
 REDIS_PORT=6379
-REDIS_PASSWORD=notion-check-plz
+REDIS_PASSWORD=
 REDIS_DB=0
 REDIS_KEY_PREFIX=vd2:
 CACHE_DEFAULT_TTL=300
 
 # Slack Notification
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services
+SLACK_WEBHOOK_URL=
 
 # Sentry Hook
-SENTRY_CLIENT_SECRET=374708bedd34ae70f814471ff24db7dedc4b9bee06a7e8ef9255a4f6c8bd9049 # 실제 키를 사용하세요
-SENTRY_DSN=https://ingest.us.sentry.io
+SENTRY_CLIENT_SECRET=
+SENTRY_DSN=

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ SYSTEM_DESIGN.md
 
 # 환경 변수 및 인증 정보
 .env
+.env.prod
 .env.local
 .env.*.local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ./logs/api:/usr/src/app/logs
     env_file:
-      - .env
+      - .env.prod
     environment:
       NODE_ENV: production
       TZ: Asia/Seoul

--- a/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
+++ b/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
@@ -12,7 +12,7 @@ import { PostLeaderboardSortType, UserLeaderboardSortType } from '@/types';
 import { getKSTDateStringWithOffset } from '@/utils/date.util';
 
 dotenv.config();
-jest.setTimeout(45000); // 각 케이스당 45초 타임아웃 설정
+jest.setTimeout(60000); // 각 케이스당 60초 타임아웃 설정
 
 /**
  * LeaderboardRepository 통합 테스트

--- a/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
+++ b/src/repositories/__test__/integration/leaderboard.repo.integration.test.ts
@@ -12,7 +12,7 @@ import { PostLeaderboardSortType, UserLeaderboardSortType } from '@/types';
 import { getKSTDateStringWithOffset } from '@/utils/date.util';
 
 dotenv.config();
-jest.setTimeout(30000); // 각 케이스당 30초 타임아웃 설정
+jest.setTimeout(45000); // 각 케이스당 45초 타임아웃 설정
 
 /**
  * LeaderboardRepository 통합 테스트


### PR DESCRIPTION
## 🔥 변경 사항

- 로컬/운영 환경변수를 분리하였습니다. [값 참고](https://www.notion.so/nuung/13d6299fd6668029964ee00b9f6049db?source=copy_link#1a26299fd66680f3b827ee45d79e22c1)
- 로컬(`.env`): 평소처럼 `pnpm dev`를 통해 실행하면 됨
- 운영(`.env.prod`): `run.sh`나 `docker compose up`을 통해 실행시 자동으로 prod 값이 주입됨
- 로컬에서 운영 환경변수로 실행이 필요할때 `dotenv.config({ path: '.env.prod' })`를 통해 경로를 설정해주면 되지만, 번거로울 수 있어 그냥 `.env` 값을 잠시 바꾸는 것을 추천


## 🏷 관련 이슈
- X

## 📸 스크린샷 (UI 변경 시 필수)
X

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경 샘플(.env.sample)의 기본값을 빈값·로컬호스트 중심으로 정리 (외부 URL/고정 키/시크릿 제거).
  * `.gitignore`에 프로덕션 환경 파일(.env.prod) 추가.
  * 도커 컴포즈 설정이 컨테이너 환경을 `.env.prod`에서 로드하도록 업데이트.
* **Tests**
  * 일부 통합 테스트의 타임아웃을 30초에서 60초로 늘려 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->